### PR TITLE
Fix OpenClaw nvidia provider missing models array

### DIFF
--- a/bin/free-coding-models.js
+++ b/bin/free-coding-models.js
@@ -1103,8 +1103,13 @@ async function startOpenClaw(model, apiKey) {
     config.models.providers.nvidia = {
       baseUrl: 'https://integrate.api.nvidia.com/v1',
       api: 'openai-completions',
+      models: [],
     }
     console.log(chalk.dim('  ➕ Added nvidia provider block to OpenClaw config (models.providers.nvidia)'))
+  }
+  // 📖 Ensure models array exists even if the provider block was created by an older version
+  if (!Array.isArray(config.models.providers.nvidia.models)) {
+    config.models.providers.nvidia.models = []
   }
 
   // 📖 Store API key in the root "env" section so OpenClaw can read it as NVIDIA_API_KEY env var.


### PR DESCRIPTION
## Summary

- `startOpenClaw()` creates the nvidia provider block without a `models` property, causing OpenClaw's Zod schema validation to reject the config with: `models.providers.nvidia.models: Invalid input: expected array, received undefined`
- Add `models: []` to the provider block and a safety net for configs written by older versions that are missing the property

## Details

The two standalone patch scripts (`patch-openclaw.js` and `patch-openclaw-models.js`) already include `models: []` when creating provider blocks. This was the only code path that omitted it.

The safety net (`Array.isArray` check) handles existing configs written before this fix, converting `undefined`/`null`/non-array values to an empty array.

## Test plan

- [x] `npm test` -- all 63 tests pass
- [ ] Run `free-coding-models --openclaw`, select a model, verify `~/.openclaw/openclaw.json` has `models.providers.nvidia.models` as an array
- [ ] Run `openclaw gateway restart` -- no schema validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)