### PR TITLE
feat: add Fireworks AI provider and fallback model suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ Thumbs.db
 
 # 11. Local-only telemetry POC (kept out of this repo on purpose)
 private-telemetry/
+
+#12 Txt files
+*.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## 0.1.63
 
+### Added
+
+- **Fireworks AI provider**: added new provider with 11 models including Llama 4 Maverick, DeepSeek V3, QwQ 32B, Qwen2.5 Coder 32B, Llama 3.1 405B, R1 Distill 70B, Llama 3.3 70B, Mixtral 8x22B, Llama 3.1 8B, R1 Distill 7B, and Gemma 3 27B. API key available via `FIREWORKS_API_KEY` env var or config file.
+- **Fallback model suggestions**: when a model shows "Overloaded" (HTTP 429 rate limit), the TUI now displays a suggestion line below it with the best alternative model from the same tier or lower. Includes model name, tier, provider, and average latency.
+
 ### Changed
 
 - Replaced webhook telemetry with PostHog capture API (`/i/v0/e/`) and kept explicit consent + `--no-telemetry` opt-out.

--- a/bin/free-coding-models.js
+++ b/bin/free-coding-models.js
@@ -88,7 +88,7 @@ import { homedir } from 'os'
 import { join, dirname } from 'path'
 import { MODELS, sources } from '../sources.js'
 import { patchOpenClawModelsJson } from '../patch-openclaw-models.js'
-import { getAvg, getVerdict, getUptime, sortResults, filterByTier, findBestModel, parseArgs, TIER_ORDER, VERDICT_ORDER, TIER_LETTER_MAP } from '../lib/utils.js'
+import { getAvg, getVerdict, getUptime, sortResults, filterByTier, findBestModel, findFallbackModel, parseArgs, TIER_ORDER, VERDICT_ORDER, TIER_LETTER_MAP } from '../lib/utils.js'
 import { loadConfig, saveConfig, getApiKey, isProviderEnabled } from '../lib/config.js'
 
 const require = createRequire(import.meta.url)
@@ -568,6 +568,14 @@ async function promptApiKey(config) {
       url: 'https://aistudio.google.com/apikey',
       hint: 'Get API key (free Gemma models, 14.4K req/day)',
       prefix: 'AIza',
+    },
+    {
+      key: 'fireworks',
+      label: 'Fireworks AI',
+      color: chalk.rgb(255, 80, 150),
+      url: 'https://fireworks.ai/account/api-keys',
+      hint: 'API Keys → Create key (free tier available)',
+      prefix: 'fw_',
     },
   ]
 
@@ -1078,6 +1086,21 @@ function renderTable(results, pendingPings, frame, cursor = null, sortColumn = '
       lines.push(chalk.bgRgb(139, 0, 139)(row))
     } else {
       lines.push(row)
+    }
+    
+    // 📖 Fallback suggestion for overloaded models (429 rate limit)
+    // 📖 Shows a suggestion line below the overloaded model with an alternative
+    if (r.httpCode === '429') {
+      const fallback = findFallbackModel(sorted, r)
+      if (fallback) {
+        const fallbackTier = chalk.rgb(100, 200, 255)(`[${fallback.tier}]`)
+        const fallbackName = chalk.cyan(fallback.label)
+        const fallbackProvider = chalk.dim(`(${sources[fallback.providerKey]?.name || fallback.providerKey})`)
+        const fallbackAvg = getAvg(fallback)
+        const fallbackAvgStr = fallbackAvg === Infinity ? '...' : fallbackAvg + 'ms'
+        const suggestionLine = chalk.dim('      ↳ Try: ') + fallbackTier + ' ' + fallbackName + ' ' + fallbackProvider + chalk.dim(` · ${fallbackAvgStr}`)
+        lines.push(suggestionLine)
+      }
     }
   }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -20,7 +20,8 @@
  *       "codestral":  "csk-xxx",
  *       "hyperbolic": "eyJ...",
  *       "scaleway":   "scw-xxx",
- *       "googleai":   "AIza..."
+ *       "googleai":   "AIza...",
+ *       "fireworks":  "fw_..."
  *     },
  *     "providers": {
  *       "nvidia":     { "enabled": true },
@@ -31,7 +32,8 @@
  *       "codestral":  { "enabled": true },
  *       "hyperbolic": { "enabled": true },
  *       "scaleway":   { "enabled": true },
- *       "googleai":   { "enabled": true }
+ *       "googleai":   { "enabled": true },
+ *       "fireworks":  { "enabled": true }
  *     },
  *     "telemetry": {
  *       "enabled": true,
@@ -78,6 +80,7 @@ const ENV_VARS = {
   hyperbolic: 'HYPERBOLIC_API_KEY',
   scaleway:   'SCALEWAY_API_KEY',
   googleai:   'GOOGLE_API_KEY',
+  fireworks:  'FIREWORKS_API_KEY',
 }
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,8 +33,9 @@
  *   → filterByTier(results, tierLetter) — Filter results by tier letter (S/A/B/C)
  *   → findBestModel(results) — Pick the best model by status → avg → uptime priority
  *   → parseArgs(argv) — Parse CLI arguments into structured flags and values
+ *   → findFallbackModel(results, overloadedModel, options) — Find best alternative when rate-limited
  *
- * @exports getAvg, getVerdict, getUptime, sortResults, filterByTier, findBestModel, parseArgs
+ * @exports getAvg, getVerdict, getUptime, sortResults, filterByTier, findBestModel, findFallbackModel, parseArgs
  * @exports TIER_ORDER, VERDICT_ORDER, TIER_LETTER_MAP
  *
  * @see bin/free-coding-models.js — main CLI that imports these utils
@@ -267,6 +268,76 @@ export function findBestModel(results) {
   })
 
   return sorted.length > 0 ? sorted[0] : null
+}
+
+// 📖 findFallbackModel: Find the best alternative model when a model is overloaded (429).
+// 📖 Used by the TUI to suggest alternatives when rate limiting occurs.
+//
+// 📖 Selection priority:
+//   1. Must be currently "up" (not overloaded, not down, not timeout)
+//   2. Same tier preferred, then lower tiers (never suggest higher tier)
+//   3. Lower average latency = faster = better
+//   4. Higher uptime = more reliable = better (tiebreaker)
+//
+// 📖 Parameters:
+//   - results: array of all model results
+//   - overloadedModel: the model that returned 429 (rate limited)
+//   - options: { sameTierOnly: boolean } - if true, only suggest same tier
+//
+// 📖 Returns null if no suitable fallback is found.
+export function findFallbackModel(results, overloadedModel, options = {}) {
+  const { sameTierOnly = false } = options
+  
+  // 📖 Get the tier index of the overloaded model
+  const overloadedTierIdx = TIER_ORDER.indexOf(overloadedModel.tier)
+  
+  // 📖 Filter candidates: must be "up" and not the same model
+  const candidates = results.filter(r => {
+    // 📖 Skip the overloaded model itself
+    if (r.modelId === overloadedModel.modelId && r.providerKey === overloadedModel.providerKey) {
+      return false
+    }
+    
+    // 📖 Must be currently responding (status === 'up')
+    if (r.status !== 'up') return false
+    
+    // 📖 Must not be rate-limited itself
+    if (r.httpCode === '429') return false
+    
+    // 📖 Check tier constraints
+    const candidateTierIdx = TIER_ORDER.indexOf(r.tier)
+    
+    if (sameTierOnly) {
+      // 📖 Only same tier
+      return candidateTierIdx === overloadedTierIdx
+    } else {
+      // 📖 Same tier or lower (higher index = lower tier)
+      return candidateTierIdx >= overloadedTierIdx
+    }
+  })
+  
+  if (candidates.length === 0) return null
+  
+  // 📖 Sort candidates: prefer same tier, then by latency, then by uptime
+  const sorted = candidates.sort((a, b) => {
+    const aTierIdx = TIER_ORDER.indexOf(a.tier)
+    const bTierIdx = TIER_ORDER.indexOf(b.tier)
+    
+    // 📖 Priority 1: Prefer same tier as original
+    const aSameTier = aTierIdx === overloadedTierIdx ? 0 : 1
+    const bSameTier = bTierIdx === overloadedTierIdx ? 0 : 1
+    if (aSameTier !== bSameTier) return aSameTier - bSameTier
+    
+    // 📖 Priority 2: Lower average latency = faster = better
+    const avgA = getAvg(a)
+    const avgB = getAvg(b)
+    if (avgA !== avgB) return avgA - avgB
+    
+    // 📖 Priority 3: Higher uptime = more reliable = better (tiebreaker)
+    return getUptime(b) - getUptime(a)
+  })
+  
+  return sorted[0]
 }
 
 // ─── CLI Argument Parsing ────────────────────────────────────────────────────

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,23 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      chalk:
+        specifier: ^5.4.1
+        version: 5.6.2
+
+packages:
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+snapshots:
+
+  chalk@5.6.2: {}

--- a/sources.js
+++ b/sources.js
@@ -27,8 +27,8 @@
  *   📖 Secondary: https://swe-rebench.com (independent evals, scores are lower)
  *   📖 Leaderboard tracker: https://www.marc0.dev/en/leaderboard
  *
- *   @exports nvidiaNim, groq, cerebras, sambanova, openrouter, codestral, hyperbolic, scaleway, googleai — model arrays per provider
- *   @exports sources — map of { nvidia, groq, cerebras, sambanova, openrouter, codestral, hyperbolic, scaleway, googleai } each with { name, url, models }
+ *   @exports nvidiaNim, groq, cerebras, sambanova, openrouter, codestral, hyperbolic, scaleway, googleai, fireworks — model arrays per provider
+ *   @exports sources — map of { nvidia, groq, cerebras, sambanova, openrouter, codestral, hyperbolic, scaleway, googleai, fireworks } each with { name, url, models }
  *   @exports MODELS — flat array of [modelId, label, tier, sweScore, ctx, providerKey]
  *
  *   📖 MODELS now includes providerKey as 6th element so ping() knows which
@@ -197,6 +197,29 @@ export const googleai = [
   ['gemma-3-4b-it',                            'Gemma 3 4B',         'C',  '10.0%', '128k'],
 ]
 
+// 📖 Fireworks AI source - https://fireworks.ai
+// 📖 Free tier available — API keys at https://fireworks.ai/account/api-keys
+export const fireworks = [
+  // ── S tier — SWE-bench Verified 60–70% ──
+  ['accounts/fireworks/models/llama4-maverick-instruct-basic', 'Llama 4 Maverick', 'S', '62.0%', '1M'],
+  ['accounts/fireworks/models/deepseek-v3',                    'DeepSeek V3',      'S', '62.0%', '128k'],
+  // ── A+ tier — SWE-bench Verified 50–60% ──
+  ['accounts/fireworks/models/qwq-32b',                        'QwQ 32B',          'A+', '50.0%', '131k'],
+  // ── A tier — SWE-bench Verified 40–50% ──
+  ['accounts/fireworks/models/qwen2p5-coder-32b-instruct',     'Qwen2.5 Coder 32B','A',  '46.0%', '32k'],
+  ['accounts/fireworks/models/llama3.1-405b-instruct',         'Llama 3.1 405B',   'A',  '44.0%', '128k'],
+  ['accounts/fireworks/models/deepseek-r1-distill-llama-70b',  'R1 Distill 70B',   'A',  '43.9%', '128k'],
+  // ── A- tier — SWE-bench Verified 35–40% ──
+  ['accounts/fireworks/models/llama-v3p3-70b-instruct',        'Llama 3.3 70B',    'A-', '39.5%', '128k'],
+  // ── B+ tier — SWE-bench Verified 30–35% ──
+  ['accounts/fireworks/models/mixtral-8x22b-instruct',         'Mixtral 8x22B',    'B+', '32.0%', '64k'],
+  // ── B tier — SWE-bench Verified 20–30% ──
+  ['accounts/fireworks/models/llama-v3p1-8b-instruct',         'Llama 3.1 8B',     'B',  '28.8%', '128k'],
+  ['accounts/fireworks/models/deepseek-r1-distill-qwen-7b',    'R1 Distill 7B',    'B',  '22.6%', '32k'],
+  // ── C tier — SWE-bench Verified <20% ──
+  ['accounts/fireworks/models/gemma-3-27b-it',                 'Gemma 3 27B',      'B',  '22.0%', '128k'],
+]
+
 // 📖 All sources combined - used by the main script
 // 📖 Each source has: name (display), url (API endpoint), models (array of model tuples)
 export const sources = {
@@ -244,6 +267,11 @@ export const sources = {
     name: 'Google AI',
     url: 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
     models: googleai,
+  },
+  fireworks: {
+    name: 'Fireworks',
+    url: 'https://api.fireworks.ai/inference/v1/chat/completions',
+    models: fireworks,
   },
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -27,7 +27,7 @@ const ROOT = join(__dirname, '..')
 // 📖 Import modules under test
 import { nvidiaNim, sources, MODELS } from '../sources.js'
 import {
-  getAvg, getVerdict, getUptime, sortResults, filterByTier, findBestModel, parseArgs,
+  getAvg, getVerdict, getUptime, sortResults, filterByTier, findBestModel, findFallbackModel, parseArgs,
   TIER_ORDER, VERDICT_ORDER, TIER_LETTER_MAP
 } from '../lib/utils.js'
 
@@ -332,6 +332,72 @@ describe('findBestModel', () => {
       mockResult({ label: 'Stable', status: 'up', pings: [{ ms: 300, code: '200' }, { ms: 300, code: '200' }] }),
     ]
     assert.equal(findBestModel(results).label, 'Stable')
+  })
+})
+
+describe('findFallbackModel', () => {
+  it('returns null when no alternatives available', () => {
+    const overloaded = mockResult({ label: 'Overloaded', tier: 'S', status: 'up', httpCode: '429' })
+    const results = [overloaded]
+    assert.equal(findFallbackModel(results, overloaded), null)
+  })
+
+  it('returns null when only alternative is also overloaded', () => {
+    const overloaded = mockResult({ label: 'Overloaded', tier: 'S', status: 'up', httpCode: '429' })
+    const other = mockResult({ label: 'Other', tier: 'S', status: 'up', httpCode: '429' })
+    const results = [overloaded, other]
+    assert.equal(findFallbackModel(results, overloaded), null)
+  })
+
+  it('finds fallback from same tier', () => {
+    const overloaded = mockResult({ label: 'Overloaded', tier: 'S', status: 'up', httpCode: '429', modelId: 'model1' })
+    const alternative = mockResult({ label: 'Alternative', tier: 'S', status: 'up', httpCode: '200', modelId: 'model2', pings: [{ ms: 500, code: '200' }] })
+    const results = [overloaded, alternative]
+    const fallback = findFallbackModel(results, overloaded)
+    assert.equal(fallback.label, 'Alternative')
+  })
+
+  it('prefers same tier over lower tier', () => {
+    const overloaded = mockResult({ label: 'Overloaded', tier: 'S', status: 'up', httpCode: '429', modelId: 'model1' })
+    const sameTier = mockResult({ label: 'SameTier', tier: 'S', status: 'up', httpCode: '200', modelId: 'model2', pings: [{ ms: 800, code: '200' }] })
+    const lowerTier = mockResult({ label: 'LowerTier', tier: 'A', status: 'up', httpCode: '200', modelId: 'model3', pings: [{ ms: 100, code: '200' }] })
+    const results = [overloaded, sameTier, lowerTier]
+    const fallback = findFallbackModel(results, overloaded)
+    assert.equal(fallback.label, 'SameTier')
+  })
+
+  it('finds lower tier when same tier not available', () => {
+    const overloaded = mockResult({ label: 'Overloaded', tier: 'S', status: 'up', httpCode: '429', modelId: 'model1' })
+    const lowerTier = mockResult({ label: 'LowerTier', tier: 'A', status: 'up', httpCode: '200', modelId: 'model2', pings: [{ ms: 500, code: '200' }] })
+    const results = [overloaded, lowerTier]
+    const fallback = findFallbackModel(results, overloaded)
+    assert.equal(fallback.label, 'LowerTier')
+  })
+
+  it('prefers faster model within same tier', () => {
+    const overloaded = mockResult({ label: 'Overloaded', tier: 'S', status: 'up', httpCode: '429', modelId: 'model1' })
+    const slow = mockResult({ label: 'Slow', tier: 'S', status: 'up', httpCode: '200', modelId: 'model2', pings: [{ ms: 1000, code: '200' }] })
+    const fast = mockResult({ label: 'Fast', tier: 'S', status: 'up', httpCode: '200', modelId: 'model3', pings: [{ ms: 200, code: '200' }] })
+    const results = [overloaded, slow, fast]
+    const fallback = findFallbackModel(results, overloaded)
+    assert.equal(fallback.label, 'Fast')
+  })
+
+  it('respects sameTierOnly option', () => {
+    const overloaded = mockResult({ label: 'Overloaded', tier: 'S', status: 'up', httpCode: '429', modelId: 'model1' })
+    const lowerTier = mockResult({ label: 'LowerTier', tier: 'A', status: 'up', httpCode: '200', modelId: 'model2', pings: [{ ms: 500, code: '200' }] })
+    const results = [overloaded, lowerTier]
+    const fallback = findFallbackModel(results, overloaded, { sameTierOnly: true })
+    assert.equal(fallback, null)
+  })
+
+  it('skips down models', () => {
+    const overloaded = mockResult({ label: 'Overloaded', tier: 'S', status: 'up', httpCode: '429', modelId: 'model1' })
+    const down = mockResult({ label: 'Down', tier: 'S', status: 'down', httpCode: '500', modelId: 'model2' })
+    const up = mockResult({ label: 'Up', tier: 'A', status: 'up', httpCode: '200', modelId: 'model3', pings: [{ ms: 500, code: '200' }] })
+    const results = [overloaded, down, up]
+    const fallback = findFallbackModel(results, overloaded)
+    assert.equal(fallback.label, 'Up')
   })
 })
 


### PR DESCRIPTION
- Add Fireworks AI provider with 11 models including Llama 4 Maverick, DeepSeek V3, QwQ 32B, Qwen2.5 Coder 32B, Llama 3.1 405B, R1 Distill 70B, Llama 3.3 70B, Mixtral 8x22B, Llama 3.1 8B, R1 Distill 7B, and Gemma 3 27B
- Add fallback model suggestions in TUI when a model returns HTTP 429 (rate limit), displaying the best alternative from same or lower tier
- Add findFallbackModel utility function with tier-aware selection logic
- Add FIREWORKS_API_KEY environment variable support
- Add comprehensive tests for findFallbackModel function