### PR TITLE
feat: add local auto-failover proxy router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "free-coding-models",
-  "version": "0.3.13",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "free-coding-models",
-      "version": "0.3.13",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "free-coding-models",
-  "version": "0.3.30",
+  "version": "0.4.0",
   "description": "Find the fastest coding LLM models in seconds — ping free models from multiple providers, pick the best one for OpenCode, Cursor, or any AI coding assistant.",
   "keywords": [
     "nvidia",

--- a/src/app.js
+++ b/src/app.js
@@ -109,6 +109,7 @@ import { ALT_ENTER, ALT_LEAVE, ALT_HOME, PING_TIMEOUT, PING_INTERVAL, FPS, COL_M
 import { TIER_COLOR } from '../src/tier-colors.js'
 import { resolveCloudflareUrl, buildPingRequest, ping, extractQuotaPercent, getProviderQuotaPercentCached, usagePlaceholderForProvider } from '../src/ping.js'
 import { runFiableMode, filterByTierOrExit, fetchOpenRouterFreeModels } from '../src/analysis.js'
+import { startProxyServer } from '../src/server.js'
 import { PROVIDER_METADATA, ENV_VAR_NAMES, isWindows, isMac } from '../src/provider-metadata.js'
 import { parseTelemetryEnv, isTelemetryDebugEnabled, telemetryDebug, ensureTelemetryConfig, getTelemetryDistinctId, getTelemetrySystem, getTelemetryTerminal, isTelemetryEnabled, sendUsageTelemetry, sendBugReport } from '../src/telemetry.js'
 import { ensureFavoritesConfig, toFavoriteKey, syncFavoriteFlags, toggleFavoriteModel } from '../src/favorites.js'
@@ -648,7 +649,60 @@ export async function runApp(cliArgs, config) {
     }
 
     // 📖 Apply best mode filter if specified
-    if (cliArgs.bestMode) {
+
+  // 📖 Serve mode: Headless local proxy router
+  if (cliArgs.serveMode) {
+    let results = MODELS.map(([modelId, label, tier, sweScore, ctx, providerKey], i) => ({
+      idx: i + 1,
+      modelId,
+      label,
+      tier,
+      sweScore,
+      ctx,
+      providerKey,
+      status: 'pending',
+      pings: [],
+      httpCode: null
+    }));
+
+    // Setup continuous background pings
+    const pingLoop = async () => {
+      while (true) {
+        const pingPromises = results.map(r => {
+          if (!isProviderEnabled(config, r.providerKey)) return Promise.resolve()
+          const url = sources[r.providerKey]?.url
+          const key = getApiKey(config, r.providerKey)
+          return ping(key, r.modelId, r.providerKey, url).then(({ code, ms }) => {
+            r.pings.push({ ms, code })
+            if (code === '200') {
+              r.status = 'up'
+            } else if (code === '000') {
+              r.status = 'timeout'
+            } else {
+              r.status = 'down'
+              r.httpCode = code
+            }
+          }).catch(() => {})
+        })
+        await Promise.allSettled(pingPromises)
+        await new Promise(res => setTimeout(res, 60000))
+      }
+    }
+    pingLoop()
+
+    const stateRef = { current: { results } }
+    console.log(chalk.cyan('  🚀 Starting Local Proxy Server...'))
+    const { port } = await startProxyServer(8080, stateRef, config)
+    console.log(chalk.green(`  ✓ Proxy running on http://127.0.0.1:${port}/v1`))
+    console.log(chalk.dim('  Point your tools to this endpoint (model names will be dynamically routed)'))
+    return
+  }
+
+//   if (cliArgs.fiableMode) {
+    await runFiableMode(config)
+    return
+  }
+  if (cliArgs.bestMode) {
       outputResults = outputResults.filter(r => ['S+', 'S', 'A+'].includes(r.tier))
     }
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,126 @@
+import { createServer } from 'node:http'
+import chalk from 'chalk'
+import { SOURCES } from '../sources.js'
+import { findBestModel } from './utils.js'
+import { getApiKey } from './config.js'
+
+export async function startProxyServer(port = 8080, stateRef, config) {
+  const server = createServer(async (req, res) => {
+    // Basic CORS and Preflight
+    res.setHeader('Access-Control-Allow-Origin', '*')
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(200)
+      res.end()
+      return
+    }
+
+    if (req.method !== 'POST' || !req.url.endsWith('/v1/chat/completions')) {
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: 'Only POST /v1/chat/completions is supported' }))
+      return
+    }
+
+    let body = ''
+    for await (const chunk of req) {
+      body += chunk
+    }
+
+    let parsedBody
+    try {
+      parsedBody = JSON.parse(body)
+    } catch (e) {
+      res.writeHead(400, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: 'Invalid JSON' }))
+      return
+    }
+
+    // Proxy routing logic
+    const results = stateRef.current.results
+    // Use the actual models list from state, filtered by what's available
+    const availableResults = results.filter(r => r.status === 'up' || r.status === 'pending')
+    const bestModelResult = findBestModel(availableResults)
+
+    if (!bestModelResult) {
+      res.writeHead(503, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: 'No free models currently available or configured.' }))
+      return
+    }
+
+    const providerMetadata = SOURCES[bestModelResult.providerKey]
+    const apiKey = getApiKey(config, bestModelResult.providerKey)
+
+    if (!apiKey) {
+        res.writeHead(503, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: `No API key configured for best model provider: ${bestModelResult.providerKey}` }))
+        return
+    }
+
+    // Modify the payload to use the actual model ID
+    parsedBody.model = bestModelResult.modelId
+
+    try {
+      // 📖 Important: we do not handle streaming fallback perfectly here yet
+      // but we pipe the response exactly as it comes
+      const fetchHeaders = {
+        'Content-Type': 'application/json',
+      }
+      if (apiKey !== 'nokey') {
+          fetchHeaders['Authorization'] = `Bearer ${apiKey}`
+      }
+
+      // 📖 We should forward custom headers if the provider requires it.
+      // E.g., OpenRouter requires HTTP-Referer
+      if (providerMetadata.headers) {
+          Object.assign(fetchHeaders, providerMetadata.headers)
+      }
+
+      const providerRes = await fetch(providerMetadata.url, {
+        method: 'POST',
+        headers: fetchHeaders,
+        body: JSON.stringify(parsedBody)
+      })
+
+      // Forward status and headers
+      const resHeaders = {
+         'Content-Type': providerRes.headers.get('content-type') || 'application/json',
+      }
+      if (providerRes.headers.get('Transfer-Encoding') === 'chunked') {
+          resHeaders['Transfer-Encoding'] = 'chunked'
+      }
+      res.writeHead(providerRes.status, resHeaders)
+
+      if (providerRes.body) {
+        // Node 18+ web streams to node streams
+        const reader = providerRes.body.getReader();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          res.write(value);
+        }
+        res.end();
+      } else {
+         const text = await providerRes.text()
+         res.end(text)
+      }
+
+    } catch (err) {
+      console.error(chalk.red(`[Proxy Error] Failed to route to ${bestModelResult.modelId}:`), err.message)
+      if (!res.headersSent) {
+          res.writeHead(500, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ error: 'Internal proxy error', details: err.message }))
+      } else {
+          res.end()
+      }
+    }
+  })
+
+  return new Promise((resolve, reject) => {
+    server.on('error', reject)
+    server.listen(port, '127.0.0.1', () => {
+      resolve({ server, port })
+    })
+  })
+}

--- a/src/tool-launchers.js
+++ b/src/tool-launchers.js
@@ -150,6 +150,21 @@ export function buildToolEnv(mode, model, config, options = {}) {
     includeProviderEnv = true,
     inheritedEnv = process.env,
   } = options
+
+  if (config.serveModeActive) {
+    const env = cloneInheritedEnv(inheritedEnv, sanitize ? SANITIZED_TOOL_ENV_KEYS : [])
+    const proxyUrl = 'http://127.0.0.1:8080/v1'
+    const proxyKey = 'nokey-localproxy'
+    if (includeCompatDefaults) {
+      env.OPENAI_API_KEY = proxyKey
+      env.OPENAI_BASE_URL = proxyUrl
+      env.OPENAI_API_BASE = proxyUrl
+      env.OPENAI_MODEL = model.modelId
+    }
+    return { env, apiKey: proxyKey, baseUrl: proxyUrl }
+  }
+
+
   const providerKey = model.providerKey
   const providerUrl = sources[providerKey]?.url || ''
   const baseUrl = getProviderBaseUrl(providerKey)

--- a/src/utils.js
+++ b/src/utils.js
@@ -393,7 +393,8 @@ export function findBestModel(results) {
 //   - Value flag: --tier <letter> (the next non-flag arg is the tier value)
 //
 // 📖 Returns:
-//   { apiKey, bestMode, fiableMode, openCodeMode, openCodeDesktopMode, openClawMode,
+//   { apiKey, bestMode,
+//     serveMode, fiableMode, openCodeMode, openCodeDesktopMode, openClawMode,
 //     aiderMode, crushMode, gooseMode, qwenMode, openHandsMode, ampMode,
 //     piMode, noTelemetry, jsonMode, helpMode, tierFilter }
 //
@@ -443,6 +444,7 @@ export function parseArgs(argv) {
   }
 
   const bestMode = flags.includes('--best')
+  const serveMode = flags.includes('--serve') || args.includes('serve')
   const fiableMode = flags.includes('--fiable')
   const openCodeMode = flags.includes('--opencode')
   const openCodeDesktopMode = flags.includes('--opencode-desktop')
@@ -481,6 +483,7 @@ export function parseArgs(argv) {
   return {
     apiKey,
     bestMode,
+    serveMode,
     fiableMode,
     openCodeMode,
     openCodeDesktopMode,


### PR DESCRIPTION
- Added `serveMode` flag to CLI arguments for spinning up a local proxy
- Created `src/server.js` with proxy logic capable of auto-routing OpenAI payloads to the currently best performing free model endpoint
- Integrated `startProxyServer` in `src/app.js` headless loop keeping pings alive and redirecting traffic
- Adjusted external tool launchers to automatically fallback to `127.0.0.1:8080/v1` dummy endpoint setup if configured in proxy serve mode

---
*PR created automatically by Jules for task [13877929107902989012](https://jules.google.com/task/13877929107902989012) started by @vava-nessa*