### PR TITLE
fix(router): canonicalize proxied content-type header

### DIFF
--- a/src/router-daemon.js
+++ b/src/router-daemon.js
@@ -242,14 +242,19 @@ function attachClientAbort(req, res, controller) {
   }
 }
 
-function cloneHeadersForUpstream(reqHeaders, apiKey, providerKey) {
+export function cloneHeadersForUpstream(reqHeaders, apiKey, providerKey) {
   const headers = {}
   for (const [key, value] of Object.entries(reqHeaders || {})) {
     const lower = key.toLowerCase()
     if (['host', 'connection', 'content-length', 'authorization'].includes(lower)) continue
-    if (typeof value === 'string') headers[key] = value
+    if (typeof value !== 'string') continue
+    if (lower === 'content-type') {
+      headers['Content-Type'] = value
+      continue
+    }
+    headers[key] = value
   }
-  headers['Content-Type'] = headers['Content-Type'] || headers['content-type'] || 'application/json'
+  headers['Content-Type'] = headers['Content-Type'] || 'application/json'
   headers.Authorization = `Bearer ${apiKey}`
   if (providerKey === 'openrouter') {
     headers['HTTP-Referer'] = 'https://github.com/vava-nessa/free-coding-models'

--- a/test/test.js
+++ b/test/test.js
@@ -47,7 +47,7 @@ import {
   normalizeRouterConfig,
   DEFAULT_ROUTER_SETTINGS
 } from '../src/config.js'
-import { buildDefaultRouterSet, createRouterRuntimeForTest, formatOpenAiError } from '../src/router-daemon.js'
+import { buildDefaultRouterSet, cloneHeadersForUpstream, createRouterRuntimeForTest, formatOpenAiError } from '../src/router-daemon.js'
 import { formatRouterDuration, normalizeRouterDashboardSnapshot, parseRouterDashboardSseFrame } from '../src/router-dashboard.js'
 import { buildProviderModelTokenKey, loadTokenUsageByProviderModel, formatTokenTotalCompact } from '../src/token-usage-reader.js'
 import { renderTable } from '../src/render-table.js'
@@ -2386,6 +2386,15 @@ describe('router config helpers', () => {
 })
 
 describe('router daemon integration hardening', () => {
+  it('canonicalizes content-type before proxying upstream requests', () => {
+    const actual = cloneHeadersForUpstream({ 'content-type': 'application/json', accept: 'application/json' }, 'router-test-key', 'groq')
+
+    assert.equal(actual['Content-Type'], 'application/json')
+    assert.equal(actual['content-type'], undefined)
+    assert.equal(actual.Authorization, 'Bearer router-test-key')
+    assert.equal(actual.accept, 'application/json')
+  })
+
   it('routes non-streaming chat completions through the highest-priority healthy model', async () => {
     await withMockProvider(() => ({
       body: {


### PR DESCRIPTION
## Summary

This fixes a small but real proxying bug in the router daemon: when an incoming client sends `content-type` in lowercase, we currently forward that header **and** also add `Content-Type`, which can leave upstream requests with duplicate content-type casing.

Most providers tolerate that, but some stricter OpenAI-compatible gateways reject it and return `400 Unsupported Media Type` even though the payload itself is valid JSON.

## What changed

- canonicalize proxied `content-type` to a single `Content-Type` header
- avoid forwarding the original lowercase key alongside the canonical one
- keep all other passthrough headers unchanged
- add a regression test for the header normalization behavior

## Why this matters

I hit this while testing the FCM Router against a real upstream during ForgeCode integration work. Probes passed, but real routed requests failed because the upstream saw duplicate content-type headers.

After this change, routed requests only send one content-type header:

- before: `content-type` + `Content-Type`
- after: `Content-Type`

## Testing

- `pnpm test`
- `pnpm start -- --daemon-status`
