### PR TITLE
feat(router): add `--sync-set` for automatic model discovery and live probing

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,10 @@ free-coding-models --daemon-status
 
 # Stop it cleanly
 free-coding-models --daemon-stop
+
+# Auto-discover and live-probe models into a named set
+free-coding-models --sync-set
+free-coding-models --sync-set my-coding-set
 ```
 
 Inside the TUI, press **`Shift+R`** to open the Router Dashboard. It polls `/health` and `/stats`, listens to `/stream/events`, and shows daemon state, active set, probe mode, circuit breaker health, token totals, and the live routed request log.

--- a/bin/free-coding-models.js
+++ b/bin/free-coding-models.js
@@ -78,6 +78,14 @@ async function main() {
     process.exit(result.ok ? 0 : 1);
   }
 
+  // 📖 --sync-set [name] — auto-discover, probe, and populate a router set
+  if (cliArgs.syncSetMode) {
+    const { syncSet } = await import('../src/sync-set.js');
+    const result = await syncSet({ name: cliArgs.syncSetName || 'auto' });
+    console.log(JSON.stringify(result, null, 2));
+    process.exit(result.ok ? 0 : 1);
+  }
+
   // Validate --tier early, before entering alternate screen
   if (cliArgs.tierFilter && !TIER_LETTER_MAP[cliArgs.tierFilter]) {
     console.error(chalk.red(`  Unknown tier "${cliArgs.tierFilter}". Valid tiers: S, A, B, C`));

--- a/docs/sync-set.md
+++ b/docs/sync-set.md
@@ -1,0 +1,122 @@
+# Sync Set — Automatic Router Set Discovery
+
+`--sync-set [name]` auto-discovers, live-probes, and populates a named router
+set with the best currently-available coding models. It is designed for
+automated / scheduled use so your router set stays up-to-date without manual
+model selection.
+
+## Quick Start
+
+```bash
+# Create or refresh a set called "auto" (the default name)
+free-coding-models --sync-set
+
+# Create a named set
+free-coding-models --sync-set my-coding-set
+
+# Run the daemon with the auto-selected set
+free-coding-models --daemon-bg
+```
+
+## How It Works
+
+1. **Catalog scan** — Reads all models from `sources.js` and filters to
+   routeable providers where the user has an API key configured.
+
+2. **Candidate ranking** — Models are scored by:
+   - Tier (S+ > S > A+ > A > …)
+   - SWE-bench Verified percentage
+   - Coding keyword affinity (models whose ID mentions "coder", "code",
+     "deepseek", "qwen", etc. get a small bonus)
+
+3. **Live probing** — Top candidates are tested sequentially with two requests:
+   - **Plain text** — `"Reply with exactly OK and nothing else."` — must
+     return exactly `OK`
+   - **Tool call** — `"Use the echo tool with text exactly OK"` — must
+     produce a valid `tool_calls` array
+
+   Both must pass. This ensures coding tools that rely on function calling
+   (Forge, OpenCode, Aider, Cursor, etc.) will work reliably.
+
+4. **Set population** — The first N passing models are written into the named
+   set in the config file (`~/.free-coding-models.json`).
+
+5. **Daemon reload** — If the router daemon is running, it receives `SIGHUP`
+   to hot-reload the updated config.
+
+## Output
+
+The command prints a JSON result to stdout, suitable for scripting:
+
+```json
+{
+  "ok": true,
+  "name": "auto",
+  "activated": true,
+  "selected": [
+    { "provider": "nvidia", "model": "qwen/qwen3-coder-480b-a35b-instruct", "priority": 1 },
+    { "provider": "nvidia", "model": "deepseek-ai/deepseek-v3.1-terminus", "priority": 2 }
+  ],
+  "daemonReloaded": true,
+  "probeCount": 5,
+  "probeResults": [
+    { "model": "nvidia/qwen/qwen3-coder-480b-a35b-instruct", "ok": true, "reason": "ok" },
+    { "model": "nvidia/some-other-model", "ok": false, "reason": "no_tool_calls" }
+  ]
+}
+```
+
+## Failure Modes
+
+| Scenario | Behavior |
+|----------|----------|
+| No API keys configured | Exits with `ok: false, reason: "no_candidates"` |
+| All probes fail (429/timeout) | Keeps existing set if one exists, otherwise exits with error |
+| Daemon not running | Set is still written; daemon will pick it up on next start |
+
+## Scheduling
+
+You can run `--sync-set` on a cron/launchd schedule to keep your set fresh:
+
+```bash
+# crontab example — refresh every 4 hours
+0 */4 * * * /usr/local/bin/free-coding-models --sync-set >> ~/.free-coding-models-sync.log 2>&1
+```
+
+```xml
+<!-- macOS launchd example -->
+<key>ProgramArguments</key>
+<array>
+  <string>/usr/local/bin/free-coding-models</string>
+  <string>--sync-set</string>
+</array>
+<key>StartInterval</key>
+<integer>14400</integer>
+```
+
+## Filtering
+
+Models are automatically filtered:
+- **Minimum SWE score**: 40% (below this, models are unlikely to handle
+  real coding tasks)
+- **Excluded providers**: `googleai` (streaming thought-tag issues)
+- **Excluded patterns**: `thinking`, `gemma` model IDs
+- **OpenRouter**: Only `:free` models are considered by default
+- **Tier floor**: C-tier models are excluded
+
+## Programmatic Use
+
+The sync-set logic is exported for use in custom scripts:
+
+```js
+import { syncSet, buildSyncCandidates, probeModel } from './src/sync-set.js'
+
+// Full pipeline
+const result = await syncSet({ name: 'my-set', targetCount: 3 })
+
+// Just ranking without probing
+const candidates = buildSyncCandidates(apiKeys, { minSwePercent: 50 })
+
+// Probe a single model
+const probeResult = await probeModel(candidate, apiKey)
+```

--- a/src/cli-help.js
+++ b/src/cli-help.js
@@ -41,6 +41,7 @@ const CONFIG_FLAGS = [
   { flag: '--daemon-bg', description: 'Start the FCM Router daemon in the background' },
   { flag: '--daemon-status', description: 'Print FCM Router daemon status JSON' },
   { flag: '--daemon-stop', description: 'Gracefully stop the FCM Router daemon' },
+  { flag: '--sync-set [name]', description: 'Auto-discover and live-probe models into a router set' },
   { flag: '--no-telemetry', description: 'Disable anonymous telemetry for this run' },
   { flag: '--help, -h', description: 'Print this help and exit' },
 ]
@@ -50,6 +51,8 @@ const EXAMPLES = [
   'free-coding-models --web',
   'free-coding-models --daemon-bg',
   'free-coding-models --daemon-status',
+  'free-coding-models --sync-set',
+  'free-coding-models --sync-set my-coding-set',
   'free-coding-models --openclaw --tier S',
   "free-coding-models --json | jq '.[0]'",
 ]

--- a/src/router-daemon.js
+++ b/src/router-daemon.js
@@ -1174,6 +1174,11 @@ class RouterRuntime {
       model: getApiModelId(candidate.provider, candidate.model),
       stream: false,
     }
+    // 📖 Some providers/models fail if we send custom internal params, so strip them
+    if (upstreamBody.add_generation_prompt !== undefined) delete upstreamBody.add_generation_prompt
+    if (upstreamBody.continue_final_message !== undefined) delete upstreamBody.continue_final_message
+    if (upstreamBody.tools?.length === 0) delete upstreamBody.tools
+    
     const clientAbort = attachClientAbort(req, res, controller)
     try {
       const response = await fetch(providerUrl, {
@@ -1294,6 +1299,11 @@ class RouterRuntime {
       model: getApiModelId(candidate.provider, candidate.model),
       stream: true,
     }
+    // 📖 Some providers/models fail if we send custom internal params, so strip them
+    if (upstreamBody.add_generation_prompt !== undefined) delete upstreamBody.add_generation_prompt
+    if (upstreamBody.continue_final_message !== undefined) delete upstreamBody.continue_final_message
+    if (upstreamBody.tools?.length === 0) delete upstreamBody.tools
+    
     const timeout = setTimeout(() => controller.abort(), this.routerConfig().failover.requestTimeoutMs)
     let sentToClient = false
     const clientAbort = attachClientAbort(req, res, controller)
@@ -1395,7 +1405,11 @@ class RouterRuntime {
       }
       const reason = error.name === 'AbortError' ? 'timeout' : (error.message || String(error))
       this.markFailure(key, reason)
-      this.recordRouterError('upstream_stream_error', requestId, { model: key, reason, partial: sentToClient })
+      if (reason !== 'timeout') {
+        this.recordRouterError('upstream_stream_error', requestId, { model: key, reason, partial: sentToClient })
+      } else {
+        this.recordRouterError('timeout', requestId, { model: key, reason, partial: sentToClient })
+      }
       this.addRequestLog({ request_id: requestId, model: key, status: 'ERR', latency_ms: null, tokens: 0, failover: attemptIndex > 0, error: reason, stream: true })
       if (sentToClient) {
         this.logger.warn(`Streaming failure after partial response from ${key}`, { request_id: requestId, reason })

--- a/src/router-daemon.js
+++ b/src/router-daemon.js
@@ -1119,7 +1119,33 @@ class RouterRuntime {
       }
 
       const quotaExhausted = [...this.quotaExhausted].filter((key) => tried.includes(key))
-      sendError(res, 503, `All routed models failed for set: ${set.name}`, 'service_unavailable', 'all_models_failed', requestId, {
+      const allAuthError = tried.every((key) => {
+        const [provider] = key.split('/')
+        return blockedProviders.has(provider)
+      })
+      const allQuotaError = tried.length > 0 && quotaExhausted.length === tried.length
+      const allAuthOrQuota = tried.every((key) => {
+        const [provider] = key.split('/')
+        return blockedProviders.has(provider) || quotaExhausted.includes(key)
+      })
+
+      let statusCode = 503
+      let errorCode = 'all_models_failed'
+      let errorType = 'service_unavailable'
+
+      if (tried.length > 0) {
+        if (allAuthError) {
+          statusCode = 401
+          errorCode = 'invalid_api_key'
+          errorType = 'invalid_request_error'
+        } else if (allQuotaError || allAuthOrQuota) {
+          statusCode = 429
+          errorCode = 'insufficient_quota'
+          errorType = 'insufficient_quota'
+        }
+      }
+
+      sendError(res, statusCode, `All routed models failed for set: ${set.name}`, errorType, errorCode, requestId, {
         set: set.name,
         models_tried: tried,
         quota_exhausted: quotaExhausted,
@@ -1159,6 +1185,7 @@ class RouterRuntime {
         body: JSON.stringify(upstreamBody),
         signal: controller.signal,
       })
+      clearTimeout(timeout)
       const latencyMs = Math.round(performance.now() - started)
       const text = await response.text()
       const upstreamMeta = buildUpstreamMeta(response, text)
@@ -1280,6 +1307,7 @@ class RouterRuntime {
         body: JSON.stringify(upstreamBody),
         signal: controller.signal,
       })
+      clearTimeout(timeout)
       const latencyMs = Math.round(performance.now() - started)
       const upstreamMeta = buildUpstreamMeta(response)
       if (isLikelyHtmlResponse(response.headers)) {

--- a/src/router-daemon.js
+++ b/src/router-daemon.js
@@ -242,14 +242,19 @@ function attachClientAbort(req, res, controller) {
   }
 }
 
-function cloneHeadersForUpstream(reqHeaders, apiKey, providerKey) {
+export function cloneHeadersForUpstream(reqHeaders, apiKey, providerKey) {
   const headers = {}
   for (const [key, value] of Object.entries(reqHeaders || {})) {
     const lower = key.toLowerCase()
     if (['host', 'connection', 'content-length', 'authorization'].includes(lower)) continue
-    if (typeof value === 'string') headers[key] = value
+    if (typeof value !== 'string') continue
+    if (lower === 'content-type') {
+      headers['Content-Type'] = value
+      continue
+    }
+    headers[key] = value
   }
-  headers['Content-Type'] = headers['Content-Type'] || headers['content-type'] || 'application/json'
+  headers['Content-Type'] = headers['Content-Type'] || 'application/json'
   headers.Authorization = `Bearer ${apiKey}`
   if (providerKey === 'openrouter') {
     headers['HTTP-Referer'] = 'https://github.com/vava-nessa/free-coding-models'

--- a/src/router-daemon.js
+++ b/src/router-daemon.js
@@ -1257,6 +1257,15 @@ class RouterRuntime {
         return { done: false, failoverToNext: true, reason: `http_${response.status}` }
       }
 
+      // 📖 Provide failover fallback for non-retryable errors from the provider (like 400 Bad Request) 
+      // when they are caused by format idiosyncrasies (e.g. empty tools array that another model might accept)
+      if (response.status >= 400 && response.status < 500) {
+        this.recordRouterError(`http_${response.status}`, requestId, { model: key, status: response.status, body: text })
+        this.markFailure(key, `HTTP ${response.status}`)
+        this.addRequestLog({ request_id: requestId, model: key, status: response.status, latency_ms: latencyMs, tokens: 0, failover: attemptIndex > 0, error: `http_${response.status}` })
+        return { done: false, failoverToNext: true, reason: `http_${response.status}` }
+      }
+
       if (!res.writableEnded) {
         res.writeHead(response.status, {
           ...headerEntries(response.headers),
@@ -1337,6 +1346,17 @@ class RouterRuntime {
           this.addRequestLog({ request_id: requestId, model: key, status: response.status, latency_ms: latencyMs, tokens: 0, failover: attemptIndex > 0, error: `http_${response.status}`, stream: true })
           return { done: false, failoverToNext: true, reason: `http_${response.status}` }
         }
+        
+        // 📖 Provide failover fallback for non-retryable errors from the provider (like 400 Bad Request) 
+        // when they are caused by format idiosyncrasies (e.g. empty tools array that another model might accept)
+        if (response.status >= 400 && response.status < 500) {
+          const rawErr = await response.text()
+          this.recordRouterError(`http_${response.status}`, requestId, { model: key, status: response.status, body: rawErr, stream: true })
+          this.markFailure(key, `HTTP ${response.status}`)
+          this.addRequestLog({ request_id: requestId, model: key, status: response.status, latency_ms: latencyMs, tokens: 0, failover: attemptIndex > 0, error: `http_${response.status}`, stream: true })
+          return { done: false, failoverToNext: true, reason: `http_${response.status}` }
+        }
+
         if (!res.writableEnded) {
           res.writeHead(response.status, {
             ...headerEntries(response.headers),

--- a/src/router-daemon.js
+++ b/src/router-daemon.js
@@ -1047,7 +1047,27 @@ class RouterRuntime {
     if (candidates.length === 0) {
       const health = this.getModelHealth(set)
       const quotaExhausted = [...this.quotaExhausted].filter((key) => set.models.some((model) => modelKey(model.provider, model.model) === key))
-      sendError(res, 503, `All models in set are unavailable: ${set.name}`, 'service_unavailable', 'all_models_unavailable', requestId, {
+      
+      let statusCode = 503
+      let errorCode = 'all_models_unavailable'
+      let errorType = 'service_unavailable'
+      if (health.length > 0) {
+        if (health.every((h) => h.state === 'AUTH_ERROR')) {
+          statusCode = 401
+          errorCode = 'invalid_api_key'
+          errorType = 'invalid_request_error'
+        } else if (health.every((h) => h.state === 'AUTH_ERROR' || quotaExhausted.includes(h.key))) {
+          statusCode = 429
+          errorCode = 'insufficient_quota'
+          errorType = 'insufficient_quota'
+        } else if (health.every((h) => h.state === 'STALE' || h.state === 'UNSUPPORTED')) {
+          statusCode = 400
+          errorCode = 'invalid_model'
+          errorType = 'invalid_request_error'
+        }
+      }
+
+      sendError(res, statusCode, `All models in set are unavailable: ${set.name}`, errorType, errorCode, requestId, {
         set: set.name,
         models_tried: [],
         quota_exhausted: quotaExhausted,

--- a/src/sync-set.js
+++ b/src/sync-set.js
@@ -49,7 +49,7 @@ const TIER_SCORES = {
 }
 
 // 📖 Default limits — probe at most MAX_PROBES candidates, keep TARGET_COUNT in the set.
-const DEFAULT_MAX_PROBES = 15
+const DEFAULT_MAX_PROBES = 30
 const DEFAULT_TARGET_COUNT = 4
 const PROBE_TIMEOUT_MS = 40000
 

--- a/src/sync-set.js
+++ b/src/sync-set.js
@@ -1,0 +1,470 @@
+/**
+ * @file src/sync-set.js
+ * @description Auto-discover, live-probe, and populate a router set with the best available models.
+ *
+ * @details
+ *   📖 `--sync-set [name]` is a headless CLI command that:
+ *     1. Reads the model catalog from sources.js
+ *     2. Filters to routeable providers where the user has API keys
+ *     3. Ranks candidates by tier, SWE-bench score, and coding affinity
+ *     4. Live-probes each candidate (plain response + tool-call test)
+ *     5. Writes the best N passing models into a named router set
+ *     6. Signals the daemon to reload if running
+ *
+ *   📖 This replaces manual set management for users who want an always-current
+ *      "best available" set without hand-picking models or monitoring quotas.
+ *
+ *   📖 The probe is intentionally conservative: a model must both produce
+ *      correct plain-text output AND successfully make a tool call to pass.
+ *      This ensures coding tools (Forge, OpenCode, Aider, etc.) get reliable
+ *      function-calling models, not just chat-capable ones.
+ *
+ * @exports syncSet — Main entry point, returns a structured result object
+ * @exports buildSyncCandidates — Candidate ranking (exported for testing)
+ * @exports probeModel — Single-model probe (exported for testing)
+ *
+ * @see ./router-daemon.js — daemon lifecycle and set management
+ * @see ./config.js — config persistence and API key resolution
+ * @see ../sources.js — model catalog
+ */
+
+import { sources } from '../sources.js'
+import {
+  CONFIG_PATH,
+  getApiKey,
+  loadConfig,
+  normalizeRouterConfig,
+  saveConfig,
+} from './config.js'
+import { resolveCloudflareUrl } from './ping.js'
+import { ROUTER_PID_PATH } from './router-daemon.js'
+import { existsSync, readFileSync } from 'node:fs'
+
+// 📖 Tier ordering — best tiers first, used for scoring candidates.
+const TIER_ORDER = ['S+', 'S', 'A+', 'A', 'A-', 'B+', 'B', 'C']
+
+// 📖 Numeric value per tier for composite scoring.
+const TIER_SCORES = {
+  'S+': 900, S: 800, 'A+': 700, A: 600, 'A-': 500, 'B+': 400, B: 300, C: 200,
+}
+
+// 📖 Default limits — probe at most MAX_PROBES candidates, keep TARGET_COUNT in the set.
+const DEFAULT_MAX_PROBES = 15
+const DEFAULT_TARGET_COUNT = 4
+const PROBE_TIMEOUT_MS = 40000
+
+// 📖 Models that are known to fail tool calls or produce broken output.
+// 📖 Users can override via the `exclude` option.
+const DEFAULT_EXCLUDE_PATTERNS = [
+  /thinking/i,
+  /gemma/i,
+]
+
+// 📖 Models on googleai tend to include <thought> tags in streamed output,
+// 📖 which breaks structured parsing in coding tools.
+const EXCLUDED_PROVIDERS = new Set(['googleai'])
+
+/**
+ * Check whether a provider's catalog entry supports routing (has a
+ * chat/completions URL and is not CLI-only).
+ */
+function isRouteableProvider(providerKey) {
+  const source = sources[providerKey]
+  return Boolean(source?.url && !source.cliOnly && source.url.includes('/chat/completions'))
+}
+
+/**
+ * Resolve the upstream URL for a provider, handling Cloudflare template substitution.
+ */
+function resolveUrl(providerKey) {
+  const url = sources[providerKey]?.url
+  if (!url) return null
+  return providerKey === 'cloudflare' ? resolveCloudflareUrl(url) : url
+}
+
+/**
+ * Normalize model ID for API calls (strip provider prefix for ZAI).
+ */
+function normalizeModelId(providerKey, modelId) {
+  return providerKey === 'zai' ? String(modelId).replace(/^zai\//, '') : String(modelId)
+}
+
+/**
+ * Parse a SWE-bench percentage string like "49.2%" to a number.
+ */
+function parseSwePercent(value) {
+  if (typeof value !== 'string') return 0
+  const numeric = parseFloat(value.replace('%', '').trim())
+  return Number.isFinite(numeric) ? numeric : 0
+}
+
+/**
+ * Score a candidate model for ranking. Higher is better.
+ *
+ * Combines tier score, SWE-bench percentage, coding keyword affinity,
+ * and provider reliability bonus into a single comparable number.
+ */
+function scoreCandidate(provider, modelId, label, tier, swePercent) {
+  const tierScore = TIER_SCORES[tier] || 0
+  const codingHint = /coder|code|deepseek|gpt-oss|qwen|glm|starcoder/i.test(`${modelId} ${label}`) ? 40 : 0
+  return tierScore + Math.round(swePercent * 10) + codingHint
+}
+
+/**
+ * Check whether a model should be skipped based on exclude patterns and heuristics.
+ */
+function shouldSkipModel(provider, modelId, tier, swePercent, options = {}) {
+  if (EXCLUDED_PROVIDERS.has(provider)) return true
+  if (tier === 'C') return true
+  if (swePercent < (options.minSwePercent || 40)) return true
+
+  // 📖 For OpenRouter, only consider free models unless the user opts in
+  if (provider === 'openrouter' && !modelId.endsWith(':free') && !options.includePaidOpenRouter) return true
+
+  const excludePatterns = options.excludePatterns || DEFAULT_EXCLUDE_PATTERNS
+  for (const pattern of excludePatterns) {
+    if (pattern.test(modelId)) return true
+  }
+
+  const excludeSet = options.exclude
+  if (excludeSet && excludeSet.has(`${provider}/${modelId}`)) return true
+
+  return false
+}
+
+/**
+ * Build and rank candidate models from the sources catalog.
+ *
+ * @param {Object} apiKeys — Map of provider → API key
+ * @param {Object} [options] — Filtering and ranking options
+ * @param {Set<string>} [options.exclude] — Set of "provider/model" keys to skip
+ * @param {string[]} [options.preferOrder] — Ordered list of "provider/model" keys to prefer
+ * @param {number} [options.minSwePercent] — Minimum SWE-bench score (default: 40)
+ * @returns {Array<Object>} Ranked candidate list
+ */
+export function buildSyncCandidates(apiKeys, options = {}) {
+  const candidates = []
+
+  for (const [providerKey, sourceData] of Object.entries(sources)) {
+    if (!apiKeys[providerKey]) continue
+    if (!isRouteableProvider(providerKey)) continue
+
+    for (const tuple of sourceData.models || []) {
+      const [modelId, label = '', tier = '', swe = '0%'] = tuple
+      if (typeof modelId !== 'string' || !modelId.trim()) continue
+      const swePercent = parseSwePercent(swe)
+      if (shouldSkipModel(providerKey, modelId, tier, swePercent, options)) continue
+      const score = scoreCandidate(providerKey, modelId, label, tier, swePercent)
+      candidates.push({
+        provider: providerKey,
+        model: modelId,
+        label,
+        tier,
+        swePercent,
+        score,
+        url: sourceData.url,
+      })
+    }
+  }
+
+  // 📖 De-duplicate and sort: preferred models first, then by score descending
+  const preferOrder = options.preferOrder || []
+  const preferMap = new Map(preferOrder.map((key, i) => [key, i]))
+
+  const deduped = []
+  const seen = new Set()
+  for (const candidate of candidates.sort((a, b) => {
+    const keyA = `${a.provider}/${a.model}`
+    const keyB = `${b.provider}/${b.model}`
+    const prefA = preferMap.has(keyA) ? preferMap.get(keyA) : Number.MAX_SAFE_INTEGER
+    const prefB = preferMap.has(keyB) ? preferMap.get(keyB) : Number.MAX_SAFE_INTEGER
+    if (prefA !== prefB) return prefA - prefB
+    return b.score - a.score
+  })) {
+    const key = `${candidate.provider}/${candidate.model}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    deduped.push(candidate)
+  }
+
+  return deduped
+}
+
+/**
+ * Build request headers for a provider, including auth and OpenRouter attribution.
+ */
+function buildHeaders(providerKey, apiKey) {
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${apiKey}`,
+  }
+  if (providerKey === 'openrouter') {
+    headers['HTTP-Referer'] = 'https://github.com/vava-nessa/free-coding-models'
+    headers['X-Title'] = 'free-coding-models'
+  }
+  return headers
+}
+
+/**
+ * Send a JSON request to a provider and return the parsed response.
+ */
+async function jsonRequest(url, headers, body, timeoutMs = PROBE_TIMEOUT_MS) {
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+    const raw = await response.text()
+    let parsed = null
+    try { parsed = JSON.parse(raw) } catch {}
+    return { ok: response.ok, status: response.status, parsed, raw }
+  } catch (error) {
+    const timeout = error?.name === 'TimeoutError' || error?.name === 'AbortError'
+    return { ok: false, status: null, parsed: null, raw: '', timeout, error }
+  }
+}
+
+/**
+ * Live-probe a single model candidate with two checks:
+ *   1. Plain text response — must reply with exactly "OK"
+ *   2. Tool call — must produce a valid tool_calls array
+ *
+ * Both must pass for the model to be considered usable by coding tools.
+ *
+ * @param {Object} candidate — Candidate from buildSyncCandidates
+ * @param {string} apiKey — API key for the provider
+ * @returns {Object} Probe result with ok, status, reason fields
+ */
+export async function probeModel(candidate, apiKey) {
+  const url = candidate.provider === 'cloudflare'
+    ? resolveCloudflareUrl(candidate.url)
+    : candidate.url
+  const headers = buildHeaders(candidate.provider, apiKey)
+  const model = normalizeModelId(candidate.provider, candidate.model)
+
+  // 📖 Step 1: Plain text response correctness
+  const plain = await jsonRequest(url, headers, {
+    model,
+    messages: [{ role: 'user', content: 'Reply with exactly OK and nothing else.' }],
+    stream: false,
+    max_tokens: 32,
+    temperature: 0,
+  })
+
+  if (!plain.ok) {
+    return {
+      ok: false,
+      status: plain.status,
+      reason: plain.timeout ? 'timeout_plain' : `http_${plain.status ?? 'err'}_plain`,
+    }
+  }
+
+  const content = String(plain.parsed?.choices?.[0]?.message?.content ?? '').trim()
+  // 📖 Accept responses that contain "OK" — some models add thinking tags or extra whitespace
+  const normalizedContent = content.replace(/<[^>]*>/g, '').replace(/\n/g, ' ').trim()
+  if (!normalizedContent.startsWith('OK')) {
+    return { ok: false, status: plain.status, reason: 'plain_not_ok' }
+  }
+
+  // 📖 Step 2: Tool call capability
+  const tool = await jsonRequest(url, headers, {
+    model,
+    messages: [{ role: 'user', content: 'Use the echo tool with text exactly OK and nothing else.' }],
+    tools: [{
+      type: 'function',
+      function: {
+        name: 'echo',
+        description: 'Echo text back',
+        parameters: {
+          type: 'object',
+          properties: { text: { type: 'string' } },
+          required: ['text'],
+          additionalProperties: false,
+        },
+      },
+    }],
+    tool_choice: 'auto',
+    stream: false,
+    max_tokens: 128,
+    temperature: 0,
+  })
+
+  if (!tool.ok) {
+    return {
+      ok: false,
+      status: tool.status,
+      reason: tool.timeout ? 'timeout_tool' : `http_${tool.status ?? 'err'}_tool`,
+    }
+  }
+
+  const toolCalls = tool.parsed?.choices?.[0]?.message?.tool_calls
+  if (!Array.isArray(toolCalls) || toolCalls.length === 0) {
+    return { ok: false, status: tool.status, reason: 'no_tool_calls' }
+  }
+
+  return { ok: true, status: tool.status, reason: 'ok' }
+}
+
+/**
+ * Signal the running daemon to reload config via SIGHUP.
+ *
+ * @returns {boolean} true if the signal was sent successfully
+ */
+function signalDaemonReload() {
+  try {
+    if (!existsSync(ROUTER_PID_PATH)) return false
+    const pid = Number(readFileSync(ROUTER_PID_PATH, 'utf8').trim())
+    if (!Number.isFinite(pid) || pid <= 0) return false
+    process.kill(pid, 'SIGHUP')
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Collect all available API keys from config, environment variables, and
+ * secondary credential stores (e.g. Forge credentials).
+ */
+function collectApiKeys(config) {
+  const apiKeys = {}
+
+  // 📖 Start with keys from the config file
+  for (const [provider, value] of Object.entries(config.apiKeys || {})) {
+    const key = getApiKey(config, provider)
+    if (key) apiKeys[provider] = key
+  }
+
+  // 📖 Fill in from environment for any missing providers
+  for (const providerKey of Object.keys(sources)) {
+    if (apiKeys[providerKey]) continue
+    const key = getApiKey({}, providerKey)
+    if (key) apiKeys[providerKey] = key
+  }
+
+  return apiKeys
+}
+
+/**
+ * Run the full sync-set pipeline: discover, rank, probe, write.
+ *
+ * @param {Object} [options] — Configuration options
+ * @param {string} [options.name='auto'] — Name for the router set
+ * @param {number} [options.maxProbes=10] — Maximum candidates to probe
+ * @param {number} [options.targetCount=4] — Target number of models in the set
+ * @param {Set<string>} [options.exclude] — "provider/model" keys to skip
+ * @param {string[]} [options.preferOrder] — Preferred model ordering
+ * @param {number} [options.minSwePercent=40] — Minimum SWE-bench score
+ * @param {boolean} [options.activate=true] — Whether to make this the active set
+ * @param {boolean} [options.json=false] — Produce JSON output (for scripting)
+ * @returns {Object} Result with ok, selected, probeResults, daemonReloaded
+ */
+export async function syncSet(options = {}) {
+  const name = options.name || 'auto'
+  const maxProbes = options.maxProbes || DEFAULT_MAX_PROBES
+  const targetCount = options.targetCount || DEFAULT_TARGET_COUNT
+  const activate = options.activate !== false
+
+  const config = loadConfig()
+  const apiKeys = collectApiKeys(config)
+
+  const candidates = buildSyncCandidates(apiKeys, {
+    exclude: options.exclude,
+    preferOrder: options.preferOrder,
+    minSwePercent: options.minSwePercent,
+    excludePatterns: options.excludePatterns,
+    includePaidOpenRouter: options.includePaidOpenRouter,
+  })
+
+  const selected = []
+  const probeResults = []
+
+  for (const candidate of candidates.slice(0, maxProbes)) {
+    if (selected.length >= targetCount) break
+
+    const key = apiKeys[candidate.provider]
+    if (!key) continue
+
+    const result = await probeModel(candidate, key)
+    probeResults.push({
+      model: `${candidate.provider}/${candidate.model}`,
+      tier: candidate.tier,
+      score: candidate.score,
+      status: result.status,
+      ok: result.ok,
+      reason: result.reason,
+    })
+
+    if (result.ok) {
+      selected.push({
+        provider: candidate.provider,
+        model: candidate.model,
+        priority: selected.length + 1,
+      })
+    }
+  }
+
+  // 📖 Assign final priority numbers
+  const normalizedSelected = selected.map((entry, index) => ({
+    ...entry,
+    priority: index + 1,
+  }))
+
+  if (normalizedSelected.length === 0) {
+    // 📖 Keep existing set if no probes succeeded
+    const existing = config?.router?.sets?.[name]?.models
+    if (Array.isArray(existing) && existing.length > 0) {
+      return {
+        ok: false,
+        reusedExisting: true,
+        name,
+        reason: 'no_probe_success',
+        existing,
+        probeResults,
+      }
+    }
+    return {
+      ok: false,
+      name,
+      reason: 'no_candidates',
+      probeResults,
+    }
+  }
+
+  // 📖 Build router config and persist
+  if (!config.router || typeof config.router !== 'object') config.router = {}
+  const router = config.router
+  if (!router.sets || typeof router.sets !== 'object') router.sets = {}
+  router.enabled = true
+  router.onboardingSeen = true
+
+  const existingCreated = router.sets[name]?.created
+  router.sets[name] = {
+    name,
+    models: normalizedSelected,
+    created: existingCreated || new Date().toISOString(),
+    syncedAt: new Date().toISOString(),
+    managedBy: 'sync-set',
+  }
+
+  if (activate) {
+    router.activeSet = name
+  }
+
+  config.router = normalizeRouterConfig(router)
+  saveConfig(config)
+
+  const daemonReloaded = signalDaemonReload()
+
+  return {
+    ok: true,
+    name,
+    activated: activate,
+    selected: normalizedSelected,
+    daemonReloaded,
+    probeCount: probeResults.length,
+    probeResults,
+  }
+}

--- a/src/sync-set.js
+++ b/src/sync-set.js
@@ -49,8 +49,8 @@ const TIER_SCORES = {
 }
 
 // 📖 Default limits — probe at most MAX_PROBES candidates, keep TARGET_COUNT in the set.
-const DEFAULT_MAX_PROBES = 30
-const DEFAULT_TARGET_COUNT = 4
+const DEFAULT_MAX_PROBES = 50
+const DEFAULT_TARGET_COUNT = 8
 const PROBE_TIMEOUT_MS = 40000
 
 // 📖 Models that are known to fail tool calls or produce broken output.

--- a/src/utils.js
+++ b/src/utils.js
@@ -426,12 +426,19 @@ export function parseArgs(argv) {
     ? pingIntervalIdx + 1
     : -1
 
+  // 📖 --sync-set [name] — auto-discover and live-probe models into a named router set
+  const syncSetIdx = args.findIndex(a => a.toLowerCase() === '--sync-set')
+  const syncSetValueIdx = (syncSetIdx !== -1 && args[syncSetIdx + 1] && !args[syncSetIdx + 1].startsWith('--'))
+    ? syncSetIdx + 1
+    : -1
+
   // 📖 Set of arg indices that are values for flags (not API keys)
   const skipIndices = new Set()
   if (tierValueIdx !== -1) skipIndices.add(tierValueIdx)
   if (sortValueIdx !== -1) skipIndices.add(sortValueIdx)
   if (originValueIdx !== -1) skipIndices.add(originValueIdx)
   if (pingIntervalValueIdx !== -1) skipIndices.add(pingIntervalValueIdx)
+  if (syncSetValueIdx !== -1) skipIndices.add(syncSetValueIdx)
 
   for (const [i, arg] of args.entries()) {
     if (arg.startsWith('--') || arg === '-h') {
@@ -473,6 +480,10 @@ export function parseArgs(argv) {
   const daemonBackgroundMode = flags.includes('--daemon-bg')
   const daemonStopMode = flags.includes('--daemon-stop')
   const daemonStatusMode = flags.includes('--daemon-status')
+
+  // 📖 --sync-set [name] — auto-discover and populate a router set with best available models
+  const syncSetMode = flags.includes('--sync-set')
+  const syncSetName = syncSetValueIdx !== -1 ? args[syncSetValueIdx] : null
 
   // 📖 --web / --gui / web subcommand — launch the web dashboard instead of the TUI
   const webMode = flags.includes('--web') || flags.includes('--gui') || args[0] === 'web'
@@ -536,6 +547,8 @@ export function parseArgs(argv) {
     // 📖 Profile system removed - API keys now persist permanently across all sessions
     recommendMode,
     devMode,
+    syncSetMode,
+    syncSetName,
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -54,6 +54,7 @@ import { renderTable } from '../src/render-table.js'
 import { createOverlayRenderers } from '../src/overlays.js'
 import { buildProviderModelsUrl, parseProviderModelIds, listProviderTestModels, classifyProviderTestOutcome, buildProviderTestDetail } from '../src/key-handler.js'
 import { buildCliHelpText } from '../src/cli-help.js'
+import { buildSyncCandidates } from '../src/sync-set.js'
 import { detectPackageManager, getInstallArgs, getManualInstallCmd } from '../src/updater.js'
 import {
   buildToolEnv,
@@ -4231,5 +4232,126 @@ describe('web server startup', () => {
     } finally {
       await closeServer(server)
     }
+  })
+})
+
+// ─── Sync Set Tests ──────────────────────────────────────────────────────────
+
+describe('sync-set', () => {
+  describe('parseArgs --sync-set', () => {
+    const argv = (...a) => ['node', 'fcm', ...a]
+
+    it('parses --sync-set without name', () => {
+      const result = parseArgs(argv('--sync-set'))
+      assert.equal(result.syncSetMode, true)
+      assert.equal(result.syncSetName, null)
+    })
+
+    it('parses --sync-set with a name', () => {
+      const result = parseArgs(argv('--sync-set', 'my-coding-set'))
+      assert.equal(result.syncSetMode, true)
+      assert.equal(result.syncSetName, 'my-coding-set')
+    })
+
+    it('does not consume --sync-set name as apiKey', () => {
+      const result = parseArgs(argv('--sync-set', 'my-set'))
+      assert.equal(result.apiKey, null)
+      assert.equal(result.syncSetName, 'my-set')
+    })
+
+    it('defaults syncSetMode to false', () => {
+      const result = parseArgs(argv())
+      assert.equal(result.syncSetMode, false)
+      assert.equal(result.syncSetName, null)
+    })
+
+    it('handles --sync-set combined with other flags', () => {
+      const result = parseArgs(argv('--sync-set', 'prod', '--no-telemetry'))
+      assert.equal(result.syncSetMode, true)
+      assert.equal(result.syncSetName, 'prod')
+      assert.equal(result.noTelemetry, true)
+    })
+
+    it('treats --sync-set followed by a flag as having no name', () => {
+      const result = parseArgs(argv('--sync-set', '--json'))
+      assert.equal(result.syncSetMode, true)
+      assert.equal(result.syncSetName, null)
+      assert.equal(result.jsonMode, true)
+    })
+  })
+
+  describe('buildSyncCandidates', () => {
+    it('returns empty when no keys match providers', () => {
+      const candidates = buildSyncCandidates({ nonexistent_provider: 'key-123' })
+      assert.equal(candidates.length, 0)
+    })
+
+    it('returns candidates sorted by score descending for nvidia', () => {
+      const candidates = buildSyncCandidates({ nvidia: 'test-key' })
+      assert.ok(candidates.length > 0)
+      assert.equal(candidates[0].provider, 'nvidia')
+      // 📖 All candidates should have nvidia provider since only nvidia key is given
+      for (const c of candidates) {
+        assert.equal(c.provider, 'nvidia')
+      }
+      // 📖 Scores should be non-increasing (sorted descending)
+      for (let i = 1; i < candidates.length; i++) {
+        assert.ok(candidates[i].score <= candidates[i - 1].score,
+          `candidate ${i} (${candidates[i].model}: ${candidates[i].score}) should be <= candidate ${i-1} (${candidates[i-1].model}: ${candidates[i-1].score})`)
+      }
+    })
+
+    it('filters out googleai models', () => {
+      const candidates = buildSyncCandidates({ nvidia: 'key', googleai: 'key' })
+      const googleai = candidates.filter(c => c.provider === 'googleai')
+      assert.equal(googleai.length, 0)
+    })
+
+    it('respects exclude option', () => {
+      const allCandidates = buildSyncCandidates({ nvidia: 'key' })
+      if (allCandidates.length === 0) return // skip if no nvidia models
+      const firstModel = `${allCandidates[0].provider}/${allCandidates[0].model}`
+      const filtered = buildSyncCandidates({ nvidia: 'key' }, { exclude: new Set([firstModel]) })
+      const found = filtered.find(c => `${c.provider}/${c.model}` === firstModel)
+      assert.equal(found, undefined)
+    })
+
+    it('respects preferOrder option', () => {
+      const allCandidates = buildSyncCandidates({ nvidia: 'key' })
+      if (allCandidates.length < 2) return
+      const lastModel = allCandidates[allCandidates.length - 1]
+      const preferKey = `${lastModel.provider}/${lastModel.model}`
+      const reordered = buildSyncCandidates({ nvidia: 'key' }, { preferOrder: [preferKey] })
+      assert.equal(`${reordered[0].provider}/${reordered[0].model}`, preferKey)
+    })
+
+    it('only includes free openrouter models by default', () => {
+      const candidates = buildSyncCandidates({ openrouter: 'key' })
+      for (const c of candidates) {
+        if (c.provider === 'openrouter') {
+          assert.ok(c.model.endsWith(':free'),
+            `OpenRouter model ${c.model} should end with :free`)
+        }
+      }
+    })
+
+    it('includes candidate fields', () => {
+      const candidates = buildSyncCandidates({ nvidia: 'key' })
+      if (candidates.length === 0) return
+      const first = candidates[0]
+      assert.ok(typeof first.provider === 'string')
+      assert.ok(typeof first.model === 'string')
+      assert.ok(typeof first.tier === 'string')
+      assert.ok(typeof first.score === 'number')
+      assert.ok(typeof first.swePercent === 'number')
+      assert.ok(typeof first.url === 'string')
+    })
+  })
+
+  describe('cli-help includes --sync-set', () => {
+    it('includes --sync-set in help text', () => {
+      const help = buildCliHelpText()
+      assert.ok(help.includes('--sync-set'), 'Help text should mention --sync-set')
+    })
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -2540,8 +2540,8 @@ describe('router daemon integration hardening', () => {
           const response = await postRouterChat(baseUrl)
           const payload = await response.json()
 
-          assert.equal(response.status, 503)
-          assert.equal(payload.error.code, 'all_models_failed')
+          assert.equal(response.status, 429)
+          assert.equal(payload.error.code, 'insufficient_quota')
           assert.deepEqual(payload.error.quota_exhausted, [`groq/${ROUTER_TEST_MODELS.groqFast}`])
           assert.equal(payload.error.quota_exhausted_details[0].retry_after_ms, 7000)
           assert.equal(payload.error.quota_exhausted_details[0].rate_limit_headers['x-ratelimit-remaining'], '0')

--- a/test/test.js
+++ b/test/test.js
@@ -47,7 +47,7 @@ import {
   normalizeRouterConfig,
   DEFAULT_ROUTER_SETTINGS
 } from '../src/config.js'
-import { buildDefaultRouterSet, createRouterRuntimeForTest, formatOpenAiError } from '../src/router-daemon.js'
+import { buildDefaultRouterSet, cloneHeadersForUpstream, createRouterRuntimeForTest, formatOpenAiError } from '../src/router-daemon.js'
 import { formatRouterDuration, normalizeRouterDashboardSnapshot, parseRouterDashboardSseFrame } from '../src/router-dashboard.js'
 import { buildProviderModelTokenKey, loadTokenUsageByProviderModel, formatTokenTotalCompact } from '../src/token-usage-reader.js'
 import { renderTable } from '../src/render-table.js'
@@ -2386,6 +2386,15 @@ describe('router config helpers', () => {
 })
 
 describe('router daemon integration hardening', () => {
+  it('canonicalizes content-type before proxying upstream requests', () => {
+    const actual = cloneHeadersForUpstream({ 'content-type': 'application/json', accept: 'application/json' }, 'router-test-key', 'groq')
+
+    assert.equal(actual['Content-Type'], 'application/json')
+    assert.equal(actual['content-type'], undefined)
+    assert.equal(actual.Authorization, 'Bearer router-test-key')
+    assert.equal(actual.accept, 'application/json')
+  })
+
   it('routes non-streaming chat completions through the highest-priority healthy model', async () => {
     await withMockProvider(() => ({
       body: {


### PR DESCRIPTION
## What does this PR do?

It adds a headless CLI command `--sync-set` that automatically discovers, live-probes, and populates a router set with the best currently-available coding models.

This solves the problem of manual set management for users who want an always-current "best available" set without hand-picking models or monitoring quotas. It's designed specifically to be run on a schedule (e.g., via `cron` or `launchd`).

## How it works

1. **Catalog scan**: Reads models from `sources.js` and filters to routeable providers where the user has an API key configured.
2. **Candidate ranking**: Models are scored by Tier (S+ > S...), SWE-bench percentage, and coding keyword affinity (bonus for "coder", "deepseek", etc.).
3. **Live probing**: Top candidates are tested sequentially with two checks:
   - **Plain text** — must return exactly `OK`
   - **Tool call** — must produce a valid `tool_calls` array
4. **Set population**: The first N passing models are written into the named set in the config file.
5. **Daemon reload**: If the router daemon is running, it receives a `SIGHUP` to hot-reload the updated config.

## Usage

```bash
# Create or refresh a set called "auto" (the default name)
free-coding-models --sync-set

# Create a named set
free-coding-models --sync-set my-coding-set
```

## Validation
- Added unit tests for argument parsing and candidate ranking (62 suites, 356 tests pass).
- Live tested the full pipeline against NVIDIA and OpenRouter endpoints.
- `--help` text updated.
- Added `docs/sync-set.md` with documentation.