### PR TITLE
feat: add GitHub Copilot CLI tool support

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Routing behavior:
 | `--pi` | π Pi |
 | `--rovo` | 🦘 Rovo Dev CLI |
 | `--gemini` | ♊ Gemini CLI |
+| `--copilot` | 🤖 Copilot CLI |
 
 Press **`Z`** in the TUI to cycle between tools without restarting.
 

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -23,6 +23,7 @@ Start the TUI pre-configured to a specific tool. Press `Enter` on a model to aut
 | `--openhands` | OpenHands | Sets `LLM_MODEL` env var and launches OpenHands |
 | `--amp` | Amp | Writes model to `~/.config/amp/settings.json` and launches `amp` |
 | `--pi` | Pi | Writes model to `~/.pi/agent/settings.json` and launches `pi` |
+| `--copilot` | GitHub Copilot CLI | Sets `COPILOT_*` env vars to use the selected provider/model via BYOK |
 
 ---
 

--- a/src/app.js
+++ b/src/app.js
@@ -274,6 +274,7 @@ export async function runApp(cliArgs, config) {
       pi: cliArgs.piMode,
       rovo: cliArgs.rovoMode,
       gemini: cliArgs.geminiMode,
+      copilot: cliArgs.copilotMode,
     }
     return flagByMode[toolMode] === true
   })

--- a/src/key-handler.js
+++ b/src/key-handler.js
@@ -415,7 +415,7 @@ export function createKeyHandler(ctx) {
 
   async function launchSelectedModel(selected, options = {}) {
     const { uiAlreadyStopped = false } = options
-    userSelected = { modelId: selected.modelId, label: selected.label, tier: selected.tier, providerKey: selected.providerKey }
+    userSelected = { modelId: selected.modelId, label: selected.label, tier: selected.tier, providerKey: selected.providerKey, ctx: selected.ctx }
 
     if (!uiAlreadyStopped) {
       readline.emitKeypressEvents(process.stdin)

--- a/src/tool-bootstrap.js
+++ b/src/tool-bootstrap.js
@@ -304,6 +304,17 @@ export const TOOL_BOOTSTRAP_METADATA = {
       },
     },
   },
+  copilot: {
+    binary: 'copilot',
+    docsUrl: 'https://github.com/github/copilot',
+    install: {
+      default: {
+        shellCommand: 'npm install -g @github/copilot',
+        summary: 'Install GitHub Copilot CLI globally via npm.',
+        note: 'After installation, run `copilot` to authenticate with GitHub.',
+      },
+    },
+  },
 }
 
 export function getToolBootstrapMeta(mode) {

--- a/src/tool-launchers.js
+++ b/src/tool-launchers.js
@@ -64,6 +64,19 @@ function ensureDir(filePath) {
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
 }
 
+// 📖 Parse a context window string (e.g. "128k", "1M", "32k") to token count number.
+function parseCtxToTokens(ctx) {
+  if (!ctx || typeof ctx !== 'string') return null
+  const match = ctx.match(/^\s*(\d+(?:\.\d+)?)\s*([kKmM]?)\s*$/)
+  if (!match) return null
+  const num = parseFloat(match[1])
+  const suffix = match[2].toLowerCase()
+  // 📖 LLM token counts use binary (1024), not decimal (1000).
+  if (suffix === 'k') return Math.round(num * 1024)
+  if (suffix === 'm') return Math.round(num * 1024 * 1024)
+  return Math.round(num)
+}
+
 function getDefaultToolPaths(homeDir = homedir()) {
   return {
     aiderConfigPath: join(homeDir, '.aider.conf.yml'),
@@ -833,6 +846,32 @@ export function prepareExternalToolLaunch(mode, model, config, options = {}) {
     }
   }
 
+  if (mode === 'copilot') {
+    // 📖 copilot: set BYOK env vars so copilot uses the selected provider/model
+    const copilotModelId = resolveLauncherModelId(model)
+    env.COPILOT_PROVIDER_BASE_URL = baseUrl
+    env.COPILOT_MODEL = copilotModelId
+    if (apiKey) env.COPILOT_PROVIDER_API_KEY = apiKey
+
+    // 📖 Set context window limits from model data
+    const promptTokens = parseCtxToTokens(model.ctx)
+    if (promptTokens) env.COPILOT_PROVIDER_MAX_PROMPT_TOKENS = String(promptTokens)
+    // 📖 16k max output as a safety cap — most S+/S tier coding models
+    // 📖 support 16-32k output. copilot falls back to built-in model
+    // 📖 catalog defaults when a model ID is recognized.
+    env.COPILOT_PROVIDER_MAX_OUTPUT_TOKENS = '16384'
+
+    return {
+      command: 'copilot',
+      args: [],
+      env,
+      apiKey,
+      baseUrl,
+      meta,
+      configArtifacts: [],
+    }
+  }
+
   return {
     blocked: true,
     exitCode: 1,
@@ -931,6 +970,11 @@ export async function startExternalTool(mode, model, config) {
 
   if (mode === 'jcode') {
     console.log(chalk.dim(`  📖 Launching jcode...`))
+    return spawnCommand(resolveLaunchCommand(mode, launchPlan.command), launchPlan.args, launchPlan.env)
+  }
+
+  if (mode === 'copilot') {
+    console.log(chalk.dim(`  📖 Copilot CLI configured with model: ${model.modelId}`))
     return spawnCommand(resolveLaunchCommand(mode, launchPlan.command), launchPlan.args, launchPlan.env)
   }
 

--- a/src/tool-metadata.js
+++ b/src/tool-metadata.js
@@ -46,6 +46,7 @@ export const TOOL_METADATA = {
   jcode:             { label: 'jcode',              emoji: '🪼', flag: '--jcode',             color: [255, 140, 0]  },
   xcode:             { label: 'Xcode Intelligence',emoji: '🛠️', flag: '--xcode',            color: [20, 126, 251] },
   fcm_router:        { label: 'FCM Router',        emoji: '🧭', flag: '--fcm-router',        color: [80, 200, 120] },
+  copilot:           { label: 'Copilot CLI',       emoji: '🤖', flag: '--copilot',          color: [200, 220, 255] },
 }
 
 // 📖 Deduplicated emoji order for the "Compatible with" column.
@@ -64,13 +65,13 @@ export const COMPAT_COLUMN_SLOTS = [
   { emoji: '⚡', toolKeys: ['amp'],                          color: [255, 232, 98] },
   { emoji: '🔮', toolKeys: ['hermes'],                       color: [200, 160, 255] },
   { emoji: '▶️', toolKeys: ['continue'],                     color: [255, 100, 100] },
-{ emoji: '🧠', toolKeys: ['cline'],                       color: [100, 220, 180] },
+  { emoji: '🧠', toolKeys: ['cline'],                        color: [100, 220, 180] },
   { emoji: '🧭', toolKeys: ['fcm_router'],                  color: [80, 200, 120] },
   { emoji: '🦘', toolKeys: ['rovo'],                        color: [148, 163, 184] },
   { emoji: '♊', toolKeys: ['gemini'],                       color: [66, 165, 245] },
   { emoji: '🪼', toolKeys: ['jcode'],                        color: [255, 140, 0]  },
   { emoji: '🛠️', toolKeys: ['xcode'],                        color: [20, 126, 251] },
-  { emoji: '🧭', toolKeys: ['fcm_router'],                  color: [80, 200, 120] },
+  { emoji: '🤖', toolKeys: ['copilot'],                      color: [200, 220, 255] },
 ]
 
 export const TOOL_MODE_ORDER = [
@@ -94,6 +95,7 @@ export const TOOL_MODE_ORDER = [
   'fcm_router',
   'rovo',
   'gemini',
+  'copilot',
 ]
 
 export function getToolMeta(mode) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -389,14 +389,16 @@ export function findBestModel(results) {
 //   - API key: first positional arg that does not look like a CLI flag (e.g., "nvapi-xxx")
 //   - Boolean flags: --best, --fiable, --opencode, --opencode-desktop, --opencode-web, --openclaw,
 //     --aider, --crush, --goose, --qwen, --kilo,
-//     --openhands, --amp, --pi, --daemon, --daemon-bg, --daemon-stop,
+//     --openhands, --amp, --pi, --rovo, --hermes, --continue, --cline,
+//     --xcode, --gemini, --jcode, --copilot,
+//     --daemon, --daemon-bg, --daemon-stop,
 //     --daemon-status, --no-telemetry, --json, --help/-h (case-insensitive)
 //   - Value flag: --tier <letter> (the next non-flag arg is the tier value)
 //
 // Returns:
 //   { apiKey, bestMode, fiableMode, openCodeMode, openCodeDesktopMode, openCodeWebMode, openClawMode,
 //     aiderMode, crushMode, gooseMode, qwenMode, openHandsMode, ampMode,
-//     piMode, jcodeMode, noTelemetry, jsonMode, helpMode, tierFilter }
+//     piMode, jcodeMode, copilotMode, noTelemetry, jsonMode, helpMode, tierFilter }
 //
 // 📖 Note: apiKey may be null here — the main CLI falls back to env vars and saved config.
 export function parseArgs(argv) {
@@ -471,6 +473,7 @@ export function parseArgs(argv) {
   const xcodeMode = flags.includes('--xcode')
   const geminiMode = flags.includes('--gemini')
   const jcodeMode = flags.includes('--jcode')
+  const copilotMode = flags.includes('--copilot')
   const noTelemetry = flags.includes('--no-telemetry')
   const devMode = flags.includes('--dev')
   const jsonMode = flags.includes('--json')
@@ -528,6 +531,7 @@ export function parseArgs(argv) {
     rovoMode,
     geminiMode,
     jcodeMode,
+    copilotMode,
     noTelemetry,
     jsonMode,
     helpMode,


### PR DESCRIPTION
Integrate Copilot CLI as an external tool with BYOK configuration. Launch Copilot using the same pattern as other AI tools, passing provider and model settings via environment variables. Includes context window handling for seamless integration.