### PR TITLE
fix: regenerate pnpm-lock.yaml to unblock Docker CI

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-virtual':
+        specifier: ^3.14.2
+        version: 3.14.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -593,12 +596,21 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
+  '@tanstack/react-virtual@3.14.3':
+    resolution: {integrity: sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/store@0.7.7':
     resolution: {integrity: sha512-xa6pTan1bcaqYDS9BDpSiS63qa6EoDkPN9RsRaxHuDdVDNntzq3xNwR5YKTU/V3SkSyC9T4YVOPh2zRQN0nhIQ==}
 
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
+
+  '@tanstack/virtual-core@3.17.1':
+    resolution: {integrity: sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==}
 
   '@tiptap/core@3.26.0':
     resolution: {integrity: sha512-7jTed/RirIVsp+lLdLvGzGqF3EBGpnGHGYKOwz6t28V2BIJLAFdUhfEVdWie7xPxQNWK0TP+fPlsqZS0vxfHBg==}
@@ -2333,9 +2345,17 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  '@tanstack/react-virtual@3.14.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@tanstack/store@0.7.7': {}
 
   '@tanstack/table-core@8.21.3': {}
+
+  '@tanstack/virtual-core@3.17.1': {}
 
   '@tiptap/core@3.26.0(@tiptap/pm@3.26.0)':
     dependencies:


### PR DESCRIPTION
## Problem

Issue #122: The `@tanstack/react-virtual@^3.14.2` dependency was added to `package.json` in commit 694a258 but `pnpm install` was never run afterward, so `pnpm-lock.yaml` was never updated.

This caused the **Docker CI workflow** (`.github/workflows/docker.yml`) to fail on every run — the "Verify pnpm lockfile sync" step runs `git diff --exit-code pnpm-lock.yaml` and exits with an error when the lockfile is out of sync.

**Impact:** The GHCR Docker image has been stuck at **v0.5.32** (last successful build: June 16) while npm has received updates up to **v0.5.37** — 5 releases behind. All 8+ subsequent Docker builds have failed.

## Fix

Ran `pnpm install --no-frozen-lockfile` to regenerate `pnpm-lock.yaml` with the missing `@tanstack/react-virtual` entries (20 lines added). The lockfile is now in sync with `package.json`.

Closes #122