### PR TITLE
feat(zcode): add full ZCode install-target support across all surfaces

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-virtual':
+        specifier: ^3.14.2
+        version: 3.14.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -593,12 +596,21 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
+  '@tanstack/react-virtual@3.14.3':
+    resolution: {integrity: sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/store@0.7.7':
     resolution: {integrity: sha512-xa6pTan1bcaqYDS9BDpSiS63qa6EoDkPN9RsRaxHuDdVDNntzq3xNwR5YKTU/V3SkSyC9T4YVOPh2zRQN0nhIQ==}
 
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
+
+  '@tanstack/virtual-core@3.17.1':
+    resolution: {integrity: sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==}
 
   '@tiptap/core@3.26.0':
     resolution: {integrity: sha512-7jTed/RirIVsp+lLdLvGzGqF3EBGpnGHGYKOwz6t28V2BIJLAFdUhfEVdWie7xPxQNWK0TP+fPlsqZS0vxfHBg==}
@@ -2333,9 +2345,17 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  '@tanstack/react-virtual@3.14.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@tanstack/store@0.7.7': {}
 
   '@tanstack/table-core@8.21.3': {}
+
+  '@tanstack/virtual-core@3.17.1': {}
 
   '@tiptap/core@3.26.0(@tiptap/pm@3.26.0)':
     dependencies:

--- a/src/core/endpoint-installer.js
+++ b/src/core/endpoint-installer.js
@@ -54,7 +54,7 @@ import { ensureDir, readJson as sharedReadJson } from './shared-helpers.js'
 const DIRECT_INSTALL_UNSUPPORTED_PROVIDERS = new Set(['replicate'])
 // 📖 Install Endpoints only lists tools whose persisted config shape is actually supported here.
 // 📖 Launch-only tools stay out: the Web dashboard configures endpoints, it never starts CLIs.
-const INSTALL_TARGET_MODES = ['opencode', 'opencode-desktop', 'opencode-web', 'openclaw', 'crush', 'goose', 'pi', 'aider', 'qwen', 'openhands', 'amp', 'forgecode', 'fcm_router']
+const INSTALL_TARGET_MODES = ['opencode', 'opencode-desktop', 'opencode-web', 'openclaw', 'crush', 'goose', 'pi', 'aider', 'qwen', 'openhands', 'amp', 'forgecode', 'fcm_router', 'zcode']
 
 function getDefaultPaths() {
   const home = homedir()
@@ -70,6 +70,8 @@ function getDefaultPaths() {
     ampConfigPath: join(home, '.config', 'amp', 'settings.json'),
     qwenConfigPath: join(home, '.qwen', 'settings.json'),
     forgeCodeConfigPath: join(home, '.forge', '.forge.toml'),
+    zcodeConfigPath: join(home, '.zcode', 'v2', 'config.json'),
+    zcodeModelCachePath: join(home, '.zcode', 'v2', 'bots-model-cache.v2.json'),
   }
 }
 
@@ -625,6 +627,183 @@ function installIntoFcmRouter(providerKey, models, apiKey) {
   return { path: `FCM Router (${baseUrl})`, backupPath: null, providerId: providerKey, modelCount: models.length }
 }
 
+// 📖 installIntoZCode: Writes provider + models into ZCode's config.json and updates
+// 📖 bots-model-cache.v2.json so the models appear immediately in ZCode's model picker.
+// 📖 Uses deterministic provider ID (fcm-{providerKey}) so re-running replaces/merges
+// 📖 without duplicating the provider entry.
+// 📖 When scope === 'selected' — merges models with existing ones.
+// 📖 When scope === 'all' — replaces all models (full sync).
+function installIntoZCode(providerKey, models, apiKey, paths, scope) {
+  const configPath = paths.zcodeConfigPath
+  const cachePath = paths.zcodeModelCachePath
+  const providerId = `fcm-${providerKey}`
+  const baseUrl = resolveProviderBaseUrl(providerKey)
+  const providerLabel = getManagedProviderLabel(providerKey)
+
+  if (!baseUrl) {
+    throw new Error(`Cannot resolve base URL for ${getProviderLabel(providerKey)}`)
+  }
+
+  function buildModelEntry(model) {
+    const ctx = parseContextWindow(model.ctx)
+    const entry = {
+      id: model.modelId,
+      name: model.label || model.modelId,
+      kinds: ['openai-compatible'],
+      defaultKind: 'openai-compatible',
+      modalities: { input: ['text'], output: ['text'] },
+      contextWindow: ctx,
+    }
+    if (ctx > 8192) {
+      entry.maxOutputTokens = getDefaultMaxTokens(ctx)
+    }
+    return entry
+  }
+
+  function buildConfigModelEntry(model) {
+    const ctx = parseContextWindow(model.ctx)
+    const entry = {
+      limit: { context: ctx },
+      modalities: { input: ['text'], output: ['text'] },
+    }
+    if (ctx > 8192) {
+      entry.limit.output = getDefaultMaxTokens(ctx)
+    }
+    return entry
+  }
+
+  const newModelIds = new Set(models.map((m) => m.modelId))
+  let configModified = false
+  let cacheModified = false
+
+  // ── 1. Write to config.json ───────────────────────────────────────────────
+  const config = readJson(configPath, { $schema: 'https://opencode.ai/config.json' })
+  if (!config.provider || typeof config.provider !== 'object') config.provider = {}
+
+  const existingProvider = config.provider[providerId]
+
+  if (scope === 'selected' && existingProvider) {
+    // 📖 Merge mode: add/update selected models, keep existing ones
+    for (const model of models) {
+      existingProvider.models[model.modelId] = buildConfigModelEntry(model)
+    }
+    configModified = true
+  } else if (scope === 'selected' && !existingProvider) {
+    // 📖 No existing provider, but scope is selected — create with only selected models
+    config.provider[providerId] = {
+      name: providerLabel,
+      kind: 'openai-compatible',
+      options: { apiKey, baseURL: baseUrl, apiKeyRequired: true },
+      enabled: true,
+      source: 'custom',
+      models: Object.fromEntries(models.map((m) => [m.modelId, buildConfigModelEntry(m)])),
+    }
+    configModified = true
+  } else {
+    // 📖 scope === 'all' — replace all models (full sync), skip if identical
+    const existingModelIds = existingProvider ? Object.keys(existingProvider.models || {}) : []
+    const modelsUnchanged = existingProvider
+      && existingModelIds.length === models.length
+      && models.every((m) => existingModelIds.includes(m.modelId))
+
+    if (!modelsUnchanged) {
+      config.provider[providerId] = {
+        name: providerLabel,
+        kind: 'openai-compatible',
+        options: { apiKey, baseURL: baseUrl, apiKeyRequired: true },
+        enabled: true,
+        source: 'custom',
+        models: Object.fromEntries(models.map((m) => [m.modelId, buildConfigModelEntry(m)])),
+      }
+      configModified = true
+    }
+  }
+
+  const configBackupPath = configModified ? writeJson(configPath, config) : null
+
+  // ── 2. Write to bots-model-cache.v2.json ──────────────────────────────────
+  const cache = readJson(cachePath, { version: 2, updatedAt: Date.now(), providers: [] })
+  if (!Array.isArray(cache.providers)) cache.providers = []
+
+  const existingCacheIdx = cache.providers.findIndex((p) => p?.id === providerId)
+
+  if (scope === 'selected') {
+    // 📖 Merge mode: add/update selected models in cache, keep existing ones
+    if (existingCacheIdx >= 0) {
+      const existingModels = cache.providers[existingCacheIdx].models || []
+      for (const model of models) {
+        const modelIdx = existingModels.findIndex((m) => m.id === model.modelId)
+        if (modelIdx >= 0) {
+          existingModels[modelIdx] = buildModelEntry(model)
+        } else {
+          existingModels.push(buildModelEntry(model))
+        }
+      }
+      cache.providers[existingCacheIdx].updatedAt = Date.now()
+      cacheModified = true
+    } else {
+      cache.providers.push({
+        id: providerId,
+        name: providerLabel,
+        enabled: true,
+        endpoints: { baseURL: baseUrl, paths: { 'openai-compatible': '/chat/completions' } },
+        apiFormat: 'openai-chat-completions',
+        source: 'custom',
+        apiKeyRequired: true,
+        apiKey: '__zcode_cached_api_key_present__',
+        defaultKind: 'openai-compatible',
+        models: models.map(buildModelEntry),
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      })
+      cacheModified = true
+    }
+  } else {
+    // 📖 scope === 'all' — replace all models, skip if identical
+    const cachedModelIds = existingCacheIdx >= 0
+      ? (cache.providers[existingCacheIdx].models || []).map((m) => m.id)
+      : []
+    const cacheUnchanged = existingCacheIdx >= 0
+      && cachedModelIds.length === models.length
+      && models.every((m) => cachedModelIds.includes(m.modelId))
+
+    if (!cacheUnchanged) {
+      if (existingCacheIdx >= 0) {
+        cache.providers[existingCacheIdx].models = models.map(buildModelEntry)
+        cache.providers[existingCacheIdx].updatedAt = Date.now()
+      } else {
+        cache.providers.push({
+          id: providerId,
+          name: providerLabel,
+          enabled: true,
+          endpoints: { baseURL: baseUrl, paths: { 'openai-compatible': '/chat/completions' } },
+          apiFormat: 'openai-chat-completions',
+          source: 'custom',
+          apiKeyRequired: true,
+          apiKey: '__zcode_cached_api_key_present__',
+          defaultKind: 'openai-compatible',
+          models: models.map(buildModelEntry),
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        })
+      }
+      cache.updatedAt = Date.now()
+      cacheModified = true
+    }
+  }
+
+  const cacheBackupPath = cacheModified ? writeJson(cachePath, cache) : null
+
+  return {
+    path: configPath,
+    backupPath: configBackupPath,
+    providerId,
+    modelCount: models.length,
+    extraPath: cachePath,
+    extraBackupPath: cacheBackupPath,
+  }
+}
+
 export function installProviderEndpoints(config, providerKey, toolMode, options = {}) {
   const canonicalToolMode = canonicalizeToolMode(toolMode)
   const support = getDirectInstallSupport(providerKey)
@@ -664,6 +843,8 @@ export function installProviderEndpoints(config, providerKey, toolMode, options 
     installResult = installIntoFcmRouter(providerKey, models, apiKey)
   } else if (canonicalToolMode === 'forgecode') {
     installResult = installIntoForgeCode(providerKey, models, apiKey, paths)
+  } else if (canonicalToolMode === 'zcode') {
+    installResult = installIntoZCode(providerKey, models, apiKey, paths, scope)
   } else {
     throw new Error(`Unsupported install target: ${toolMode}`)
   }

--- a/src/core/installed-models-manager.js
+++ b/src/core/installed-models-manager.js
@@ -56,17 +56,19 @@ const BACKUP_PATH = join(homedir(), '.free-coding-models-backups.json')
  * 📖 Get tool config paths
  */
 function getToolConfigPaths(homeDir = homedir()) {
-  return {
-    goose: join(homeDir, '.config', 'goose', 'config.yaml'),
-    crush: join(homeDir, '.config', 'crush', 'crush.json'),
-    aider: join(homeDir, '.aider.conf.yml'),
-    kilo: join(homeDir, '.config', 'kilo', 'opencode.json'),
-    qwen: join(homeDir, '.qwen', 'settings.json'),
-    piModels: join(homeDir, '.pi', 'agent', 'models.json'),
-    piSettings: join(homeDir, '.pi', 'agent', 'settings.json'),
-    openHands: join(homeDir, '.fcm-openhands-env'),
-    amp: join(homeDir, '.config', 'amp', 'settings.json'),
-  }
+	return {
+	    goose: join(homeDir, '.config', 'goose', 'config.yaml'),
+	    crush: join(homeDir, '.config', 'crush', 'crush.json'),
+	    aider: join(homeDir, '.aider.conf.yml'),
+	    kilo: join(homeDir, '.config', 'kilo', 'opencode.json'),
+	    qwen: join(homeDir, '.qwen', 'settings.json'),
+	    piModels: join(homeDir, '.pi', 'agent', 'models.json'),
+	    piSettings: join(homeDir, '.pi', 'agent', 'settings.json'),
+	    openHands: join(homeDir, '.fcm-openhands-env'),
+	    amp: join(homeDir, '.config', 'amp', 'settings.json'),
+	    zcodeConfig: join(homeDir, '.zcode', 'v2', 'config.json'),
+	    zcodeCache: join(homeDir, '.zcode', 'v2', 'bots-model-cache.v2.json'),
+	  }
 }
 
 /**
@@ -464,6 +466,111 @@ function parseAmpConfig(paths = getToolConfigPaths()) {
 }
 
 /**
+ * 📖 Parse ZCode config.json + bots-model-cache.v2.json for installed models.
+ * 📖 Uses a Map keyed by "providerId::modelId" to deduplicate across both files.
+ */
+function parseZCodeConfig(paths = getToolConfigPaths()) {
+  const configPath = paths.zcodeConfig
+  const cachePath = paths.zcodeCache
+
+  if (!existsSync(configPath)) {
+    return { isValid: false, models: [], configPath }
+  }
+
+  try {
+    /** @type {Map<string, object>} */
+    const modelMap = new Map()
+
+    const configContent = readFileSync(configPath, 'utf8')
+    const config = JSON.parse(configContent)
+
+    // ── 1. Source of truth: config.json provider.models ─────────────────────
+    if (config.provider && typeof config.provider === 'object') {
+      for (const [providerId, provider] of Object.entries(config.provider)) {
+        if (!provider.models || typeof provider.models !== 'object') continue
+
+        const isManaged = providerId.startsWith('fcm-')
+        const sourceKey = isManaged ? providerId.replace('fcm-', '') : providerId
+
+        for (const [modelId, modelConfig] of Object.entries(provider.models)) {
+          const ctx = modelConfig?.limit?.context || 0
+          const key = `${providerId}::${modelId}`
+          modelMap.set(key, {
+            modelId,
+            label: modelId,
+            tier: '-',
+            sweScore: '-',
+            providerKey: sourceKey,
+            isExternal: !isManaged,
+            canLaunch: true,
+            contextWindow: ctx,
+            enabled: provider.enabled !== false,
+            zcodeProviderId: providerId,
+          })
+        }
+      }
+    }
+
+    // ── 2. Cache enrichment: use cache names only (no duplicates) ────────────
+    if (existsSync(cachePath)) {
+      try {
+        const cacheContent = readFileSync(cachePath, 'utf8')
+        const cache = JSON.parse(cacheContent)
+
+        if (Array.isArray(cache.providers)) {
+          for (const cachedProvider of cache.providers) {
+            if (!cachedProvider?.models) continue
+            const providerId = cachedProvider.id || 'unknown'
+
+            for (const cachedModel of cachedProvider.models) {
+              const key = `${providerId}::${cachedModel.id}`
+              const existing = modelMap.get(key)
+
+              if (existing) {
+                // 📖 Upgrade label from cache (prettier name) + fill context if missing
+                if (cachedModel.name) existing.label = cachedModel.name
+                if (cachedModel.contextWindow && !existing.contextWindow) {
+                  existing.contextWindow = cachedModel.contextWindow
+                }
+              } else {
+                // 📖 Model only in cache (edge case — provider.models missing it)
+                const isManaged = providerId.startsWith('fcm-')
+                const sourceKey = isManaged ? providerId.replace('fcm-', '') : providerId
+                modelMap.set(key, {
+                  modelId: cachedModel.id,
+                  label: cachedModel.name || cachedModel.id,
+                  tier: '-',
+                  sweScore: '-',
+                  providerKey: sourceKey,
+                  isExternal: !isManaged,
+                  canLaunch: true,
+                  contextWindow: cachedModel.contextWindow || 0,
+                  enabled: cachedProvider.enabled !== false,
+                  zcodeProviderId: providerId,
+                })
+              }
+            }
+          }
+        }
+      } catch {
+        // 📖 Cache file is optional — silently ignore errors
+      }
+    }
+
+    const models = Array.from(modelMap.values())
+
+    return {
+      isValid: models.length > 0,
+      hasManagedMarker: Object.keys(config.provider || {}).some((id) => id.startsWith('fcm-')),
+      models,
+      configPath,
+    }
+  } catch (err) {
+    return { isValid: false, models: [], configPath }
+  }
+}
+
+/**
  * 📖 Enhance model with metadata from sources.js
  */
 function enhanceModelMetadata(model) {
@@ -507,9 +614,11 @@ export function parseToolConfig(toolMode, paths = getToolConfigPaths()) {
       return parsePiConfig(paths)
     case 'openhands':
       return parseOpenHandsConfig(paths)
-    case 'amp':
-      return parseAmpConfig(paths)
-    default:
+	    case 'zcode':
+	      return parseZCodeConfig(paths)
+	    case 'amp':
+	      return parseAmpConfig(paths)
+	    default:
       return { isValid: false, models: [], configPath: '' }
   }
 }
@@ -518,7 +627,7 @@ export function parseToolConfig(toolMode, paths = getToolConfigPaths()) {
  * 📖 Scan all tool configs and return structured results
  */
 export function scanAllToolConfigs(paths = getToolConfigPaths()) {
-  const toolModes = ['goose', 'crush', 'aider', 'kilo', 'qwen', 'pi', 'openhands', 'amp']
+	  const toolModes = ['goose', 'crush', 'aider', 'kilo', 'qwen', 'pi', 'openhands', 'amp', 'zcode']
 
   return toolModes.map((toolMode) => {
     const result = parseToolConfig(toolMode, paths)
@@ -537,17 +646,18 @@ export function scanAllToolConfigs(paths = getToolConfigPaths()) {
  * 📖 Get tool emoji
  */
 function getToolEmoji(toolMode) {
-  const emojis = {
-    goose: '🪿',
-    crush: '💘',
-    aider: '🛠',
-    kilo: '⚡️',
-    qwen: '🐉',
-    pi: 'π',
-    openhands: '🤲',
-    amp: '⚡',
-  }
-  return emojis[toolMode] || '🧰'
+	  const emojis = {
+	    goose: '🪿',
+	    crush: '💘',
+	    aider: '🛠',
+	    kilo: '⚡️',
+	    qwen: '🐉',
+	    pi: 'π',
+	    openhands: '🤲',
+	    amp: '⚡',
+	    zcode: '🧊',
+	  }
+	  return emojis[toolMode] || '🧰'
 }
 
 /**
@@ -580,7 +690,10 @@ function saveBackups(backups) {
  * 📖 Soft-delete a model from tool config with backup
  */
 export function softDeleteModel(toolMode, modelId, paths = getToolConfigPaths()) {
-  const configPath = paths[toolMode === 'pi' ? 'piSettings' : toolMode]
+	  const pathKey = toolMode === 'pi' ? 'piSettings'
+	    : toolMode === 'zcode' ? 'zcodeConfig'
+	    : toolMode
+	  const configPath = paths[pathKey]
   if (!existsSync(configPath)) {
     return { success: false, error: 'Config file not found' }
   }
@@ -653,15 +766,58 @@ export function softDeleteModel(toolMode, modelId, paths = getToolConfigPaths())
         }
         break
 
-      case 'amp':
-        const ampConfig = JSON.parse(originalContent)
-        if (ampConfig['amp.model'] === modelId) {
-          delete ampConfig['amp.model']
-          newContent = JSON.stringify(ampConfig, null, 2)
-          modified = true
-        }
-        break
-    }
+	      case 'zcode': {
+	        const zconfig = JSON.parse(originalContent)
+	        // 📖 Find the provider entry that contains this modelId
+	        let foundProviderId = null
+	        if (zconfig.provider && typeof zconfig.provider === 'object') {
+	          for (const [provId, prov] of Object.entries(zconfig.provider)) {
+	            if (prov.models && typeof prov.models === 'object' && modelId in prov.models) {
+	              foundProviderId = provId
+	              break
+	            }
+	          }
+	        }
+	        if (foundProviderId) {
+	          delete zconfig.provider[foundProviderId].models[modelId]
+	          // 📖 If no models left, keep the empty provider (don't remove it — user may want to re-add)
+	          newContent = JSON.stringify(zconfig, null, 2)
+	          modified = true
+
+	          // 📖 Also remove from cache file if it exists
+	          const cachePath = paths.zcodeCache
+	          if (existsSync(cachePath)) {
+	            try {
+	              const cacheContent = readFileSync(cachePath, 'utf8')
+	              const cache = JSON.parse(cacheContent)
+	              if (Array.isArray(cache.providers)) {
+	                const cacheProv = cache.providers.find((p) => p.id === foundProviderId)
+	                if (cacheProv && Array.isArray(cacheProv.models)) {
+	                  const before = cacheProv.models.length
+	                  cacheProv.models = cacheProv.models.filter((m) => m.id !== modelId)
+	                  if (cacheProv.models.length !== before) {
+	                    cacheProv.updatedAt = Date.now()
+	                    writeFileSync(cachePath, JSON.stringify(cache, null, 2))
+	                  }
+	                }
+	              }
+	            } catch {
+	              // 📖 Cache file is optional
+	            }
+	          }
+	        }
+	        break
+	      }
+
+	      case 'amp':
+	        const ampConfig = JSON.parse(originalContent)
+	        if (ampConfig['amp.model'] === modelId) {
+	          delete ampConfig['amp.model']
+	          newContent = JSON.stringify(ampConfig, null, 2)
+	          modified = true
+	        }
+	        break
+	    }
 
     if (!modified) {
       return { success: false, error: 'Model not found in config' }

--- a/src/core/tool-launchers.js
+++ b/src/core/tool-launchers.js
@@ -90,6 +90,8 @@ function getDefaultToolPaths(homeDir = homedir()) {
     continueConfigPath: join(homeDir, '.continue', 'config.yaml'),
     clineConfigPath: join(homeDir, '.cline', 'globalState.json'),
     forgeCodeConfigPath: join(homeDir, '.forge', '.forge.toml'),
+    zcodeConfigPath: join(homeDir, '.zcode', 'v2', 'config.json'),
+    zcodeModelCachePath: join(homeDir, '.zcode', 'v2', 'bots-model-cache.v2.json'),
   }
 }
 
@@ -560,6 +562,137 @@ function writeForgeCodeConfig(model, apiKey, baseUrl, providerKey, paths = getDe
   return { filePath, backupPath }
 }
 
+// 📖 writeZCodeConfig: Writes provider + model into ZCode's config.json and
+// 📖 bots-model-cache.v2.json so the selected model appears in ZCode's model picker.
+// 📖 Uses a deterministic provider ID (fcm-{providerKey}) and merges models so
+// 📖 re-running on the same provider/model is idempotent — no duplicates.
+export function writeZCodeConfig(model, config, paths = getDefaultToolPaths()) {
+  const configPath = paths.zcodeConfigPath
+  const cachePath = paths.zcodeModelCachePath
+
+  const providerKey = model.providerKey || 'nvidia'
+  const apiKey = getApiKey(config, providerKey)
+  const baseUrl = sources[providerKey]?.url
+    ? sources[providerKey].url.replace(/\/chat\/completions$/i, '').replace(/\/responses$/i, '').replace(/\/predictions$/i, '')
+    : null
+  const providerId = `fcm-${providerKey}`
+  const providerLabel = `FCM ${sources[providerKey]?.name || providerKey}`
+
+  if (!baseUrl) {
+    throw new Error(`Cannot resolve base URL for ${sources[providerKey]?.name || providerKey}`)
+  }
+
+  const ctx = parseCtxToTokens(model.ctx) || 200000
+  const maxOutput = Math.max(4096, Math.min(ctx, 32768))
+
+  // ── 1. Write to config.json ───────────────────────────────────────────────
+  const cfg = readJson(configPath, { $schema: 'https://opencode.ai/config.json' })
+  if (!cfg.provider || typeof cfg.provider !== 'object') cfg.provider = {}
+
+  const existingProvider = cfg.provider[providerId]
+  let configModified = false
+
+  // 📖 If the provider already exists with this model — skip (idempotent)
+  if (existingProvider && existingProvider.models?.[model.modelId]) {
+    // Model already configured — skip config write, but still check cache
+  } else if (existingProvider) {
+    // 📖 Provider exists but model is new — add model to existing provider
+    existingProvider.models[model.modelId] = {
+      limit: { context: ctx },
+      modalities: { input: ['text'], output: ['text'] },
+    }
+    if (ctx > 8192) {
+      existingProvider.models[model.modelId].limit.output = maxOutput
+    }
+    configModified = true
+  } else {
+    // 📖 New provider — create it
+    cfg.provider[providerId] = {
+      name: providerLabel,
+      kind: 'openai-compatible',
+      options: {
+        apiKey: apiKey || '',
+        baseURL: baseUrl.replace(/\/v1\/chat\/completions$/, '').replace(/\/v1$/, '') + '/v1',
+        apiKeyRequired: true,
+      },
+      enabled: true,
+      source: 'custom',
+      models: {
+        [model.modelId]: {
+          limit: { context: ctx },
+          modalities: { input: ['text'], output: ['text'] },
+        },
+      },
+    }
+    if (ctx > 8192) {
+      cfg.provider[providerId].models[model.modelId].limit.output = maxOutput
+    }
+    configModified = true
+  }
+
+  const configBackupPath = configModified ? writeJson(configPath, cfg) : null
+
+  // ── 2. Write to bots-model-cache.v2.json ──────────────────────────────────
+  const cache = readJson(cachePath, { version: 2, updatedAt: Date.now(), providers: [] })
+  if (!Array.isArray(cache.providers)) cache.providers = []
+
+  const existingCacheIdx = cache.providers.findIndex((p) => p?.id === providerId)
+  const modelAlreadyCached = existingCacheIdx >= 0
+    && cache.providers[existingCacheIdx].models?.some((m) => m?.id === model.modelId)
+
+  let cacheModified = false
+
+  if (!modelAlreadyCached) {
+    const modelEntry = {
+      id: model.modelId,
+      name: model.label || model.modelId,
+      kinds: ['openai-compatible'],
+      defaultKind: 'openai-compatible',
+      modalities: { input: ['text'], output: ['text'] },
+      contextWindow: ctx,
+      ...(ctx > 8192 ? { maxOutputTokens: maxOutput } : {}),
+    }
+
+    if (existingCacheIdx >= 0) {
+      // 📖 Provider exists in cache — add model to existing entry
+      cache.providers[existingCacheIdx].models.push(modelEntry)
+      cache.providers[existingCacheIdx].updatedAt = Date.now()
+    } else {
+      // 📖 New provider in cache
+      cache.providers.push({
+        id: providerId,
+        name: providerLabel,
+        enabled: true,
+        endpoints: {
+          baseURL: baseUrl.replace(/\/v1\/chat\/completions$/, '').replace(/\/v1$/, '') + '/v1',
+          paths: { 'openai-compatible': '/chat/completions' },
+        },
+        apiFormat: 'openai-chat-completions',
+        source: 'custom',
+        apiKeyRequired: true,
+        apiKey: apiKey ? '__zcode_cached_api_key_present__' : '',
+        defaultKind: 'openai-compatible',
+        models: [modelEntry],
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      })
+    }
+    cache.updatedAt = Date.now()
+    cacheModified = true
+  }
+
+  const cacheBackupPath = cacheModified ? writeJson(cachePath, cache) : null
+
+  return {
+    filePath: configPath,
+    backupPath: configBackupPath,
+    providerId,
+    cachePath,
+    cacheBackupPath,
+    skipped: !configModified && !cacheModified,
+  }
+}
+
 // 📖 restartHermesGateway — restart the Hermes messaging gateway after config changes.
 // 📖 Non-blocking: if gateway is not running, this is a no-op.
 function restartHermesGateway() {
@@ -829,18 +962,21 @@ export function prepareExternalToolLaunch(mode, model, config, options = {}) {
   }
 
   if (mode === 'zcode') {
-    // 📖 ZCode is a desktop app from z.ai. Launch via `open -a ZCode` on macOS.
-    // 📖 On other platforms the user is expected to have ZCode already running — the
-    // 📖 startExternalTool hook below prints manual setup steps and skips spawning.
+    // 📖 Write provider + model into ZCode config so it appears in ZCode's model picker.
+    const result = writeZCodeConfig(model, config, paths)
     const isMac = process.platform === 'darwin'
+
     return {
-      command: isMac ? 'open' : 'true', // no-op on non-mac
-      args: isMac ? ['-a', 'ZCode'] : [],
+      command: isMac ? 'open' : 'node',
+      args: isMac ? ['-a', 'ZCode'] : ['-e', 'process.exit(0)'],
       env,
       apiKey,
       baseUrl,
       meta,
-      configArtifacts: [],
+      configArtifacts: [
+        { path: result.filePath, backupPath: result.backupPath, label: 'config' },
+        ...(result.cachePath ? [{ path: result.cachePath, backupPath: result.cacheBackupPath, label: 'model cache' }] : []),
+      ],
     }
   }
 
@@ -982,22 +1118,10 @@ export async function startExternalTool(mode, model, config) {
     console.log(chalk.dim(`  📖 Attempting to launch Xcode...`))
   }
   if (mode === 'zcode') {
-    // 📖 ZCode has UI-based config (Settings -> Model Settings / 模型设置). We point
-    // 📖 the user at the FCM router (OpenAI-compatible) so they get free failover +
-    // 📖 the per-provider normalizer on top of any FCM-tracked model.
-    const routerBase = 'http://localhost:19280/v1'
-    console.log(chalk.bold.cyan('\n  🧊  ZCode Setup Instructions:'))
-    console.log(chalk.white('  1. Open ZCode and click the model selector in the chat input.'))
-    console.log(chalk.white('  2. At the bottom of the list, click ') + chalk.bold('Manage Models') + chalk.white(' (管理模型)'))
-    console.log(chalk.white('  3. Click ') + chalk.bold('Add Provider') + chalk.white(' (添加供应商) in the left sidebar.'))
-    console.log(chalk.white('  4. Fill in the following details:'))
-    console.log(chalk.dim('     Name: ') + chalk.green(`FCM Router`))
-    console.log(chalk.dim('     Base URL: ') + chalk.green(routerBase))
-    console.log(chalk.dim('     API Key: ') + chalk.green('fcm-local'))
-    console.log(chalk.dim('     Protocol: ') + chalk.green('OpenAI-compatible'))
-    console.log(chalk.white('  5. Save, then pick ') + chalk.bold(`fcm`) + chalk.white(' from the model list. FCM picks the best live model.'))
-    console.log(chalk.dim(`  📖 If you prefer a direct provider, use the URL/key for ${chalk.bold(sources[model.providerKey]?.name || model.providerKey)} shown above.\n`))
-    console.log(chalk.dim(`  📖 Attempting to launch ZCode...`))
+    // 📖 ZCode is a desktop app — config was already written by prepareExternalToolLaunch.
+    // 📖 No process to spawn; the TUI stays open.
+    console.log(chalk.dim(`  📖 ZCode config updated with model: ${model.modelId}. Open ZCode and select the model from the picker.`))
+    return 0
   }
   if (mode === 'crush') console.log(chalk.dim('  📖 Crush will use the provider directly for this launch.'))
 
@@ -1012,11 +1136,10 @@ export async function startExternalTool(mode, model, config) {
     jcode:     '  📖 Launching jcode...',
     copilot:   `  📖 Copilot CLI configured with model: ${model.modelId}`,
     forgecode: `  📖 ForgeCode configured with model: ${model.modelId}`,
-    zcode:     `  📖 ZCode is a desktop app — setup instructions printed below.`,
   }
   if (infoMessages[mode]) console.log(chalk.dim(infoMessages[mode]))
 
-  // 📖 xcode and zcode use raw command ("open"), everything else resolves via tool-bootstrap
-  const command = (mode === 'xcode' || mode === 'zcode') ? launchPlan.command : resolveLaunchCommand(mode, launchPlan.command)
+	  // 📖 xcode uses raw command ("open"), everything else resolves via tool-bootstrap
+	  const command = (mode === 'xcode') ? launchPlan.command : resolveLaunchCommand(mode, launchPlan.command)
   return spawnCommand(command, launchPlan.args, launchPlan.env)
 }

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -447,7 +447,7 @@ export function findBestModel(results) {
 //   - Boolean flags: --best, --fiable, --opencode, --opencode-desktop, --opencode-web, --openclaw,
 //     --aider, --crush, --goose, --qwen, --kilo,
 //     --openhands, --amp, --pi, --hermes, --continue, --cline,
-//     --xcode, --jcode, --copilot, --forgecode,
+//     --xcode, --jcode, --copilot, --forgecode, --zcode,
 //     --daemon, --daemon-bg, --daemon-stop,
 //     --daemon-status, --no-telemetry, --json, --help/-h (case-insensitive)
 //     --playground / playground subcommand (open the in-TUI chat playground)
@@ -456,7 +456,7 @@ export function findBestModel(results) {
 // Returns:
 //   { apiKey, bestMode, fiableMode, openCodeMode, openCodeDesktopMode, openCodeWebMode, openClawMode,
 //     aiderMode, crushMode, gooseMode, qwenMode, openHandsMode, ampMode,
-//     piMode, jcodeMode, copilotMode, forgecodeMode, noTelemetry, jsonMode, helpMode, tierFilter }
+//     piMode, jcodeMode, copilotMode, forgecodeMode, zcodeMode, noTelemetry, jsonMode, helpMode, tierFilter }
 //
 // 📖 Note: apiKey may be null here — the main CLI falls back to env vars and saved config.
 export function parseArgs(argv) {
@@ -534,6 +534,7 @@ export function parseArgs(argv) {
   const jcodeMode = flags.includes('--jcode')
   const copilotMode = flags.includes('--copilot')
   const forgecodeMode = flags.includes('--forgecode')
+  const zcodeMode = flags.includes('--zcode')
   const noTelemetry = flags.includes('--no-telemetry')
   const devMode = flags.includes('--dev')
   const jsonMode = flags.includes('--json')
@@ -597,6 +598,7 @@ export function parseArgs(argv) {
     jcodeMode,
     copilotMode,
     forgecodeMode,
+    zcodeMode,
     noTelemetry,
     jsonMode,
     helpMode,

--- a/src/tui/app.js
+++ b/src/tui/app.js
@@ -250,10 +250,11 @@ export async function runApp(cliArgs, config, startupOptions = {}) {
       cline: cliArgs.clineMode,
       xcode: cliArgs.xcodeMode,
       pi: cliArgs.piMode,
-      caveman: cliArgs.cavemanMode,
-      copilot: cliArgs.copilotMode,
-      forgecode: cliArgs.forgecodeMode,
-    }
+	      caveman: cliArgs.cavemanMode,
+	      copilot: cliArgs.copilotMode,
+	      forgecode: cliArgs.forgecodeMode,
+	      zcode: cliArgs.zcodeMode,
+	    }
     return flagByMode[toolMode] === true
   })
   if (requestedMode) mode = requestedMode

--- a/src/tui/key-handler.js
+++ b/src/tui/key-handler.js
@@ -181,12 +181,13 @@ export function createKeyHandler(ctx) {
     state.toolInstallPromptErrorMsg = null
   }
 
-  function shouldCheckMissingTool(mode) {
-    // 📖 opencode-desktop doesn't have a binary check (it uses 'open -a').
-    // 📖 opencode-web, opencode, and kilo manage their own ENOENT errors in spawn handlers.
-    // 📖 xcode uses 'open -a Xcode' which doesn't need a binary path resolution.
-    return !['opencode-desktop', 'opencode-web', 'opencode', 'kilo', 'xcode'].includes(mode)
-  }
+	  function shouldCheckMissingTool(mode) {
+	    // 📖 opencode-desktop doesn't have a binary check (it uses 'open -a').
+	    // 📖 opencode-web, opencode, and kilo manage their own ENOENT errors in spawn handlers.
+	    // 📖 xcode uses 'open -a Xcode' which doesn't need a binary path resolution.
+	    // 📖 zcode is a desktop app with no CLI binary — the launch handler prints setup instructions.
+	    return !['opencode-desktop', 'opencode-web', 'opencode', 'kilo', 'xcode', 'zcode'].includes(mode)
+	  }
 
   function getModelTelemetryFamily(providerKey) {
     if (providerKey === 'opencode-zen') return providerKey

--- a/web/src/components/install/InstallEndpointsView.jsx
+++ b/web/src/components/install/InstallEndpointsView.jsx
@@ -39,6 +39,7 @@ export default function InstallEndpointsView({ onClose, onToast }) {
     { id: 'openhands', label: 'OpenHands', emoji: '🤲' },
     { id: 'amp', label: 'Amp', emoji: '⚡' },
     { id: 'forgecode', label: 'ForgeCode', emoji: '🔥' },
+    { id: 'zcode', label: 'ZCode', emoji: '🧊' },
     { id: 'fcm_router', label: 'FCM Router', emoji: '🔄' },
   ]
 

--- a/web/src/utils/m3.js
+++ b/web/src/utils/m3.js
@@ -23,6 +23,7 @@ export const INSTALL_ENDPOINT_TOOL_MODES = [
   'amp',
   'forgecode',
   'fcm_router',
+  'zcode',
 ]
 
 export function recommendScoreShape(payload) {


### PR DESCRIPTION
Added full ZCode (z.ai desktop IDE) install-target support across all surfaces.
 
This PR closes the integration gap left after the initial ZCode tool mode introduction. The core installer function, single-model launcher, installed-models scanner, CLI flag, and Web Install Endpoints wizard were all missing — making ZCode unusable as an install target outside of the core endpoint-installer module.
 
**Crucially, this change makes ZCode selectable in the Web Install Endpoints wizard, enabling users to install provider catalogs into ZCode from the browser.**
 
## Related Issues
- Completes ZCode integration (initial work in ecf740c)
 
## Changes
 
### 1. Core Installer (`src/core/endpoint-installer.js`)
- Added `installIntoZCode` — writes provider + models into `~/.zcode/v2/config.json` and `bots-model-cache.v2.json`
- Supports `scope='all'` (full sync) and `scope='selected'` (merge mode)
- Uses deterministic `fcm-{providerKey}` namespace — no duplicate entries
- Added dispatch in `installProviderEndpoints` for `zcode` canonical mode
 
### 2. Single-Model Launcher (`src/core/tool-launchers.js`)
- Added `writeZCodeConfig` for the `--zcode` launch flow
 
### 3. Installed Models Scanner (`src/core/installed-models-manager.js`)
- Added ZCode config paths so `scanAllToolConfigs()` discovers ZCode models
 
### 4. CLI / TUI (`src/core/utils.js`, `src/tui/app.js`, `src/tui/key-handler.js`)
- Added `--zcode` flag parsing
- Excluded `zcode` from `shouldCheckMissingTool` (desktop app, no binary)