### PR TITLE
feat: Proxmox VE deployment scripts, live router request tracking & smarter config merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,6 +893,7 @@ A: Yes — see [`sources.js`](./sources.js) for the model catalog format.
     <td align="center" width="120"><a href="https://github.com/stgreenb"><img src="https://avatars.githubusercontent.com/u/18483964?v=4&s=80" width="80" height="80" style="border-radius:50%" alt="stgreenb"></a></td>
     <td align="center" width="120"><a href="https://github.com/MoriDanWork"><img src="https://avatars.githubusercontent.com/u/55363096?v=4&s=80" width="80" height="80" style="border-radius:50%" alt="MoriDanWork"></a></td>
     <td align="center" width="120"><a href="https://github.com/fan92rus"><img src="https://avatars.githubusercontent.com/u/13201333?v=4&s=80" width="80" height="80" style="border-radius:50%" alt="fan92rus"></a></td>
+    <td align="center" width="120"><a href="https://github.com/lehneres"><img src="https://avatars.githubusercontent.com/u/7437288?v=4&s=80" width="80" height="80" style="border-radius:50%" alt="lehneres"></a></td>
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/vava-nessa"><sub><b>vava-nessa</b></sub></a></td>
@@ -905,9 +906,13 @@ A: Yes — see [`sources.js`](./sources.js) for the model catalog format.
     <td align="center"><a href="https://github.com/stgreenb"><sub><b>stgreenb</b></sub></a></td>
     <td align="center"><a href="https://github.com/MoriDanWork"><sub><b>MoriDanWork</b></sub></a></td>
     <td align="center"><a href="https://github.com/fan92rus"><sub><b>fan92rus</b></sub></a></td>
+    <td align="center"><a href="https://github.com/lehneres"><sub><b>lehneres</b></sub></a></td>
   </tr>
   <tr>
-    <td align="center" colspan="10"><sub>🛡️ <b>fan92rus</b> — Windows path traversal fix (<code>path.sep</code>)</sub></td>
+    <td align="center" colspan="11"><sub>🛡️ <b>fan92rus</b> — Windows path traversal fix (<code>path.sep</code>)</sub></td>
+  </tr>
+  <tr>
+    <td align="center" colspan="11"><sub>🚀 <b>lehneres</b> — Proxmox VE installation scripts</sub></td>
   </tr>
 </table>
 

--- a/scripts/proxmoxve-create.sh
+++ b/scripts/proxmoxve-create.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
+
+function get_header() {
+  cat << "EOF"
+  _____                  ____          _ _             __  __           _      _     
+ |  ___| __ ___  ___    / ___|___   __| (_)_ __   __ _|  \/  | ___   __| | ___| |___ 
+ | |_ | '__/ _ \/ _ \  | |   / _ \ / _` | | '_ \ / _` | |\/| |/ _ \ / _` |/ _ \ / __|
+ |  _|| | |  __/  __/  | |__| (_) | (_| | | | | | (_| | |  | | (_) | (_| |  __/ \__ \
+ |_|  |_|  \___|\___|   \____\___/ \__,_|_|_| |_|\__, |_|  |_|\___/ \__,_|\___|_|___/
+                                                 |___/                               
+EOF
+}
+
+# Copyright (c) 2021-2026 lehneres
+# Author: lehneres (https://github.com/lehneres)
+# License: MIT | https://github.com/vava-nessa/free-coding-models/raw/main/LICENSE
+# Source: https://github.com/vava-nessa/free-coding-models
+
+APP="Free Coding Models"
+var_tags="${var_tags:-ai;router}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-12}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+# Override var_install to point to our local script via path traversal trick
+var_install="../../../../vava-nessa/free-coding-models/main/scripts/proxmoxve-install"
+color
+catch_errors
+
+function update_script() {
+  header_info
+  if command -v pct >/dev/null 2>&1; then
+    check_container_storage
+    check_container_resources
+    if ! pct exec "$CTID" -- [ -d /opt/free-coding-models ]; then
+      msg_error "No ${APP} Installation Found in CT ${CTID}!"
+      exit
+    fi
+    msg_info "Updating ${APP} in CT ${CTID}..."
+    pct exec "$CTID" -- bash -c "cd /opt/free-coding-models && git checkout . && git pull && npm install --include=dev && npm run build:web && systemctl restart fcm-web"
+    pct exec "$CTID" -- bash -c "echo 'echo \"Updating Free Coding Models...\"; cd /opt/free-coding-models && git checkout . && git pull && npm install --include=dev && npm run build:web && systemctl restart fcm-web; echo \"Updated successfully\"' >/usr/bin/update && chmod +x /usr/bin/update"
+    msg_ok "Updated successfully"
+  else
+    if [ ! -d /opt/free-coding-models ]; then
+      msg_error "No ${APP} Installation Found!"
+      exit
+    fi
+    msg_info "Updating ${APP}..."
+    cd /opt/free-coding-models && git checkout . && git pull && npm install --include=dev && npm run build:web && systemctl restart fcm-web
+    msg_ok "Updated successfully"
+  fi
+  exit
+}
+
+if [[ "$1" == "update" ]]; then
+  CTID=${2:-500}
+  update_script
+fi
+
+start
+build_container
+description
+
+msg_ok "Completed successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}Access it using the following URL:${CL}"
+echo -e "${GATEWAY}${BGN}http://${IP}:19280${CL}"
+echo ""
+echo -e "${YW}Next steps:${CL}"
+echo "  1. pct enter $CTID"
+echo "  2. Edit /root/.free-coding-models.json and add your API keys"
+echo "  3. systemctl restart fcm-web"
+echo ""

--- a/scripts/proxmoxve-install.sh
+++ b/scripts/proxmoxve-install.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 lehneres
+# Author: lehneres (https://github.com/lehneres)
+# License: MIT | https://github.com/vava-nessa/free-coding-models/raw/main/LICENSE
+# Source: https://github.com/vava-nessa/free-coding-models
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  git \
+  ca-certificates \
+  curl \
+  imagemagick \
+  make \
+  g++
+msg_ok "Installed Dependencies"
+
+NODE_VERSION="22" setup_nodejs
+
+msg_info "Installing Free Coding Models"
+$STD git clone https://github.com/vava-nessa/free-coding-models.git /opt/free-coding-models
+cd /opt/free-coding-models
+$STD npm install --include=dev
+$STD npm run build:web
+msg_ok "Installed Free Coding Models"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/fcm-web.service
+[Unit]
+Description=Free Coding Models Web Dashboard
+After=network.target
+
+[Service]
+Type=simple
+User=root
+Group=root
+WorkingDirectory=/opt/free-coding-models
+ExecStart=/usr/bin/node /opt/free-coding-models/bin/free-coding-models.js web
+Restart=always
+RestartSec=10
+Environment=NODE_ENV=production
+Environment=FCM_HOST=0.0.0.0
+Environment=FCM_PORT=19280
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now fcm-web
+msg_ok "Created Service"
+
+motd_ssh
+customize
+echo 'echo "Updating Free Coding Models..."; cd /opt/free-coding-models && git checkout . && git pull && npm install --include=dev && npm run build:web && systemctl restart fcm-web; echo "Updated successfully"' >/usr/bin/update
+cleanup_lxc

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -298,12 +298,30 @@ function normalizeTelemetrySection(telemetry) {
   }
 }
 
+function normalizeSyncSection(sync) {
+  const safeSync = isPlainObject(sync) ? { ...sync } : {}
+  return {
+    enabled: typeof safeSync.enabled === 'boolean' ? safeSync.enabled : false,
+    lastSyncedAt: typeof safeSync.lastSyncedAt === 'string' ? safeSync.lastSyncedAt : null,
+  }
+}
+
+function normalizeUpdaterSection(updater) {
+  const safeUpdater = isPlainObject(updater) ? { ...updater } : {}
+  return {
+    lastCheckedAt: typeof safeUpdater.lastCheckedAt === 'string' ? safeUpdater.lastCheckedAt : null,
+    lastNotificationAt: typeof safeUpdater.lastNotificationAt === 'string' ? safeUpdater.lastNotificationAt : null,
+    skippedVersions: Array.isArray(safeUpdater.skippedVersions) ? safeUpdater.skippedVersions.filter(v => typeof v === 'string') : [],
+  }
+}
+
 function normalizeRouterName(value, fallback = '') {
   if (typeof value !== 'string') return fallback
   return value.trim().replace(/\s+/g, '-').replace(/[^a-zA-Z0-9._-]/g, '').slice(0, 64) || fallback
 }
 
 function normalizePositiveInteger(value, fallback, { min = 1, max = Number.MAX_SAFE_INTEGER } = {}) {
+  if (value === null || value === undefined || value === '') return fallback
   const numeric = Number(value)
   if (!Number.isFinite(numeric)) return fallback
   return Math.max(min, Math.min(max, Math.round(numeric)))
@@ -369,12 +387,21 @@ function normalizeRouterCircuitBreaker(circuitBreaker) {
   }
 }
 
-function normalizeRouterFailover(failover) {
+function normalizeRouterFailover(failover, routerFallback = {}) {
   const safeFailover = isPlainObject(failover) ? failover : {}
+  const numberOrNull = (val) => {
+    const n = Number(val)
+    return (val !== null && val !== '' && Number.isFinite(n)) ? n : null
+  }
+
+  const rawMaxRetries = numberOrNull(safeFailover.maxRetries) ?? numberOrNull(routerFallback.maxRetries)
+  const rawStreamStall = numberOrNull(safeFailover.streamStallTimeoutMs) ?? numberOrNull(routerFallback.streamStallTimeoutMs)
+  const rawRequestTimeout = numberOrNull(safeFailover.requestTimeoutMs) ?? numberOrNull(routerFallback.requestTimeoutMs)
+
   return {
-    maxRetries: normalizePositiveInteger(safeFailover.maxRetries, DEFAULT_ROUTER_SETTINGS.failover.maxRetries, { min: 1, max: 10 }),
-    streamStallTimeoutMs: normalizePositiveInteger(safeFailover.streamStallTimeoutMs, DEFAULT_ROUTER_SETTINGS.failover.streamStallTimeoutMs, { min: 1000, max: 120000 }),
-    requestTimeoutMs: normalizePositiveInteger(safeFailover.requestTimeoutMs, DEFAULT_ROUTER_SETTINGS.failover.requestTimeoutMs, { min: 1000, max: 300000 }),
+    maxRetries: normalizePositiveInteger(rawMaxRetries, DEFAULT_ROUTER_SETTINGS.failover.maxRetries, { min: 1, max: 20 }),
+    streamStallTimeoutMs: normalizePositiveInteger(rawStreamStall, DEFAULT_ROUTER_SETTINGS.failover.streamStallTimeoutMs, { min: 1000, max: 120000 }),
+    requestTimeoutMs: normalizePositiveInteger(rawRequestTimeout, DEFAULT_ROUTER_SETTINGS.failover.requestTimeoutMs, { min: 1000, max: 300000 }),
   }
 }
 
@@ -426,7 +453,7 @@ export function normalizeRouterConfig(router) {
     probeMode,
     probeIntervals: normalizeRouterIntervals(router.probeIntervals),
     circuitBreaker: normalizeRouterCircuitBreaker(router.circuitBreaker),
-    failover: normalizeRouterFailover(router.failover),
+    failover: normalizeRouterFailover(router.failover, router),
     scoring: normalizeRouterScoring(router.scoring),
     logLevel,
     prePrompt: normalizeRouterPrePrompt(router.prePrompt),
@@ -484,6 +511,8 @@ function normalizeConfigShape(config) {
     settings: normalizeSettingsSection(safeConfig.settings),
     favorites: normalizeFavoriteList(safeConfig.favorites),
     telemetry: normalizeTelemetrySection(safeConfig.telemetry),
+    sync: normalizeSyncSection(safeConfig.sync),
+    updater: normalizeUpdaterSection(safeConfig.updater),
     endpointInstalls: normalizeEndpointInstalls(safeConfig.endpointInstalls),
     // 📖 hiddenModels: Set of "provider/modelId" keys auto-hidden by the 404 probe (Ctrl+Shift+P).
     // 📖 Only populated when settings.autoHideBrokenModels is true (default).
@@ -551,10 +580,15 @@ export function buildPersistedConfig(incomingConfig, diskConfig = _emptyConfig()
     favorites: options.replaceFavorites === true
       ? [...normalizedIncoming.favorites]
       : mergeOrderedUniqueStrings(normalizedIncoming.favorites, normalizedDisk.favorites),
-    telemetry: {
-      ...normalizedDisk.telemetry,
-      ...normalizedIncoming.telemetry,
-    },
+    telemetry: isPlainObject(incomingConfig.telemetry)
+      ? { ...normalizedDisk.telemetry, ...normalizedIncoming.telemetry }
+      : cloneConfigValue(normalizedDisk.telemetry),
+    sync: isPlainObject(incomingConfig.sync)
+      ? { ...normalizedDisk.sync, ...normalizedIncoming.sync }
+      : cloneConfigValue(normalizedDisk.sync),
+    updater: isPlainObject(incomingConfig.updater)
+      ? { ...normalizedDisk.updater, ...normalizedIncoming.updater }
+      : cloneConfigValue(normalizedDisk.updater),
     // 📖 Managed endpoint installs sometimes need an exact snapshot so stale disk
     // 📖 records do not come back after a fresh install/refresh pass.
     endpointInstalls: options.replaceEndpointInstalls === true
@@ -562,7 +596,32 @@ export function buildPersistedConfig(incomingConfig, diskConfig = _emptyConfig()
       : mergeEndpointInstalls(normalizedDisk.endpointInstalls, normalizedIncoming.endpointInstalls),
     // 📖 Profile system removed - always null
   }
-  if (Object.prototype.hasOwnProperty.call(normalizedIncoming, 'router')) {
+  if (isPlainObject(incomingConfig.router) && isPlainObject(normalizedDisk.router)) {
+    // 📖 Deep merge router settings so partial updates (e.g. from telemetry auto-save)
+    // 📖 do not reset custom failover/scoring/intervals to defaults.
+    merged.router = {
+      ...normalizedDisk.router,
+      ...normalizedIncoming.router,
+      failover: {
+        ...normalizedDisk.router.failover,
+        ...(isPlainObject(incomingConfig.router.failover) ? normalizedIncoming.router.failover : {}),
+        // 📖 Also support top-level maxRetries/timeout overrides from incoming RAW config
+        ...(typeof incomingConfig.router.maxRetries === 'number' ? { maxRetries: incomingConfig.router.maxRetries } : {}),
+      },
+      probeIntervals: {
+        ...normalizedDisk.router.probeIntervals,
+        ...(isPlainObject(incomingConfig.router.probeIntervals) ? normalizedIncoming.router.probeIntervals : {}),
+      },
+      circuitBreaker: {
+        ...normalizedDisk.router.circuitBreaker,
+        ...(isPlainObject(incomingConfig.router.circuitBreaker) ? normalizedIncoming.router.circuitBreaker : {}),
+      },
+      scoring: {
+        ...normalizedDisk.router.scoring,
+        ...(isPlainObject(incomingConfig.router.scoring) ? normalizedIncoming.router.scoring : {}),
+      },
+    }
+  } else if (Object.prototype.hasOwnProperty.call(incomingConfig, 'router')) {
     merged.router = cloneConfigValue(normalizedIncoming.router)
   } else if (Object.prototype.hasOwnProperty.call(normalizedDisk, 'router')) {
     merged.router = cloneConfigValue(normalizedDisk.router)
@@ -1186,6 +1245,8 @@ function _emptyConfig() {
     providers: {},
     favorites: [],
     telemetry: { enabled: null, consentVersion: 0, anonymousId: null },
+    sync: { enabled: false, lastSyncedAt: null },
+    updater: { lastCheckedAt: null, lastNotificationAt: null, skippedVersions: [] },
     endpointInstalls: [],
     settings: _emptyProfileSettings(),
     hiddenModels: new Set(),

--- a/src/core/router-daemon.js
+++ b/src/core/router-daemon.js
@@ -105,6 +105,7 @@ export const ROUTER_TOKENS_PATH = join(homedir(), `.free-coding-models-tokens${_
 export function getRouterPidPath() { return join(homedir(), `.free-coding-models-daemon${_isDev() ? '-dev' : ''}.pid`) }
 export function getRouterPortPath() { return join(homedir(), `.free-coding-models-daemon${_isDev() ? '-dev' : ''}.port`) }
 export function getRouterLogPath() { return join(homedir(), `.free-coding-models-daemon${_isDev() ? '-dev' : ''}.log`) }
+export function getRouterTokensPath() { return join(homedir(), `.free-coding-models-tokens${_isDev() ? '-dev' : ''}.json`) }
 
 // 📖 Returns effective port range for current mode (dev vs production)
 export function getRouterPortRange() {
@@ -124,7 +125,7 @@ const MAX_PROBE_WINDOW = 20
 const TOKEN_FLUSH_INTERVAL_MS = 60000
 const CONFIG_RELOAD_INTERVAL_MS = 10000
 const STATS_RETENTION_DAYS = 90
-const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 529])
+const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504, 529])
 const AUTH_STATUS_CODES = new Set([401, 403])
 const RATE_LIMIT_HEADER_NAMES = [
   'retry-after',
@@ -889,6 +890,7 @@ class RouterRuntime {
     this.probeWindows = new Map()
     this.circuit = new Map()
     this.requestLog = []
+    this.activeRequests = new Map()
     this.sseClients = new Set()
     this.lastProbeAt = null
     this.totalRequestsRouted = 0
@@ -1608,6 +1610,15 @@ class RouterRuntime {
         completed: this.webGlobalBenchmarkCompleted || 0,
       },
       requestLog: this.requestLog.slice(0, 20),
+      activeRequests: Array.from(this.activeRequests.values()).map(r => ({
+        requestId: r.requestId,
+        at: r.at,
+        model: r.model,
+        current_model: r.current_model,
+        attempts: r.attempts,
+        tokens: r.tokens,
+        stalled: r.stalled
+      })),
       circuitBreakers: Object.fromEntries([...this.circuit.entries()].map(([key, value]) => [key, {
         state: value.authError ? 'AUTH_ERROR' : value.stale ? 'STALE' : value.unsupported ? 'UNSUPPORTED' : value.state,
         consecutiveFailures: value.consecutiveFailures,
@@ -1963,6 +1974,15 @@ class RouterRuntime {
   }
 
   async routeRequest({ req, res, body, setName, requestId }) {
+    this.activeRequests.set(requestId, {
+      requestId,
+      at: Date.now(),
+      model: body?.model || 'fcm',
+      current_model: null,
+      attempts: 0,
+      tokens: 0,
+      stalled: false
+    })
     if (this.shuttingDown) {
       sendError(res, 503, 'Daemon is shutting down', 'service_unavailable', 'daemon_shutting_down', requestId)
       return
@@ -1988,7 +2008,7 @@ class RouterRuntime {
 
     const candidates = this.getRoutingCandidates(set)
     const maxRetries = this.routerConfig().failover.maxRetries
-    const maxAttempts = Math.max(1, maxRetries)
+    const maxAttempts = 1 + maxRetries
     if (candidates.length === 0) {
       const health = this.getModelHealth(set)
       const quotaExhausted = [...this.quotaExhausted].filter((key) => set.models.some((model) => modelKey(model.provider, model.model) === key))
@@ -2042,6 +2062,13 @@ class RouterRuntime {
       for (const candidate of candidates) {
         if (attemptIndex >= maxAttempts) break
         if (blockedProviders.has(candidate.provider)) continue
+
+        const activeReq = this.activeRequests.get(requestId)
+        if (activeReq) {
+          activeReq.current_model = candidate.key
+          activeReq.attempts = attemptIndex + 1
+        }
+
         tried.push(candidate.key)
         const result = body.stream === true
           ? await this.proxyStreamingRequest({ req, res, body, candidate, requestId, attemptIndex })
@@ -2101,6 +2128,7 @@ class RouterRuntime {
       })
     } finally {
       this.inFlight -= 1
+      this.activeRequests.delete(requestId)
     }
   }
 
@@ -2269,6 +2297,11 @@ class RouterRuntime {
 
   async proxyStreamingRequest({ req, res, body, candidate, requestId, attemptIndex }) {
     const key = candidate.key
+    const activeReq = this.activeRequests.get(requestId)
+    if (activeReq) {
+      activeReq.current_model = key
+      if (activeReq.last_activity_at) activeReq.last_activity_at = Date.now()
+    }
     const apiKey = this.getApiKeyForProvider(candidate.provider)
     // 📖 Guard: bail early if provider URL cannot be resolved
     const providerUrl = resolveProviderUrl(candidate.provider)
@@ -2397,6 +2430,10 @@ class RouterRuntime {
         // 📖 Guard: ensure chunk value is safe for Buffer conversion
         const buf = Buffer.isBuffer(chunk.value) ? chunk.value : Buffer.from(chunk.value)
         res.write(buf)
+        if (activeReq) {
+          if (activeReq.last_activity_at) activeReq.last_activity_at = Date.now()
+          activeReq.tokens += 1 // Increment a counter to show progress
+        }
       }
 
       this.markSuccess(key, latencyMs)
@@ -2443,15 +2480,18 @@ class RouterRuntime {
           this.logger.warn(`Stream stall after partial response from ${key}, attempting failover`, { request_id: requestId, reason })
           if (!res.writableEnded) {
             try {
-              const errorPayload = JSON.stringify({
-                error: {
-                  message: `Stream truncated by router due to upstream ${reason}; failing over to next model.`,
-                  type: 'stream_error',
-                  code: 'fcm_stream_failover',
-                  reason,
-                },
+              // 📖 Issue #137: failover even after a partial response.
+              // 📖 We use a regular chat delta instead of an error payload so
+              // 📖 that clients (which often abort on "error") stay connected.
+              const failoverMsg = `\n\n> [!CAUTION]\n> Stream truncated by router due to upstream ${reason}; failing over to next model.\n\n`
+              const deltaPayload = JSON.stringify({
+                choices: [{
+                  index: 0,
+                  delta: { content: failoverMsg },
+                  finish_reason: null,
+                }],
               })
-              res.write(`data: ${errorPayload}\n\n`)
+              res.write(`data: ${deltaPayload}\n\n`)
             } catch { /* best-effort */ }
           }
           return { done: false, failoverToNext: true, reason: `stream_stall_${reason}` }
@@ -3301,8 +3341,8 @@ class RouterRuntime {
     flushProbeCache()  // 📖 t1: persist any pending probe-cache deltas before exit
     if (this.runtimeTelemetryDirty) flushRuntimeTelemetryStore()  // 📖 t3
     try { this.server?.close() } catch {}
-    try { unlinkSync(ROUTER_PID_PATH) } catch {}
-    try { unlinkSync(ROUTER_PORT_PATH) } catch {}
+    try { unlinkSync(getRouterPidPath()) } catch {}
+    try { unlinkSync(getRouterPortPath()) } catch {}
     void sendUsageTelemetry(this.config, {}, {
       event: 'app_daemon_stop',
       mode: 'daemon',
@@ -3846,16 +3886,28 @@ export async function startRouterDaemonBackground() {
 }
 
 export async function stopRouterDaemon() {
-  const pid = readNumberFile(ROUTER_PID_PATH)
-  if (!pid) return { ok: false, stopped: false, error: 'No daemon PID file found' }
+  const pidPath = getRouterPidPath()
+  let pid = readNumberFile(pidPath)
+
+  // 📖 Fallback: if the PID file is missing or invalid, try to discover the
+  // 📖 running daemon via its health port and get the PID from there.
+  if (!pid) {
+    const status = await getRouterDaemonStatus()
+    if (status.ok && status.pid) pid = status.pid
+  }
+
+  if (!pid) return { ok: false, stopped: false, error: 'No daemon PID found' }
   if (!isProcessAlive(pid)) {
-    try { unlinkSync(ROUTER_PID_PATH) } catch {}
+    try { unlinkSync(pidPath) } catch {}
     return { ok: true, stopped: false, stalePid: pid }
   }
   process.kill(pid, 'SIGTERM')
   for (let i = 0; i < 60; i += 1) {
     await sleep(250)
-    if (!isProcessAlive(pid)) return { ok: true, stopped: true, pid }
+    if (!isProcessAlive(pid)) {
+      try { unlinkSync(pidPath) } catch {}
+      return { ok: true, stopped: true, pid }
+    }
   }
   return { ok: false, stopped: false, pid, error: 'Daemon did not stop before timeout' }
 }

--- a/src/core/router-dashboard.js
+++ b/src/core/router-dashboard.js
@@ -301,6 +301,7 @@ export function normalizeRouterDashboardSnapshot(healthPayload, statsPayload) {
     models,
     routingOrder,
     requestLog,
+    activeRequests: Array.isArray(merged.activeRequests) ? merged.activeRequests : [],
   }
 }
 
@@ -1034,12 +1035,29 @@ export function renderRouterDashboard(state, deps = {}) {
   // ── Token Summary (compact, visual) ─────────────────────────────────────────
   lines.push(`  ${themeColors.textBold('📊 Tokens')}  ${themeColors.dim('Today:')} ${themeColors.info(formatTokenTotalCompact(snapshot.tokens.today.total_tokens))} ${themeColors.dim(`(${snapshot.tokens.today.requests} req)`)}  ${themeColors.dim('Lifetime:')} ${themeColors.info(formatTokenTotalCompact(snapshot.tokens.all_time.total_tokens))} ${themeColors.dim(`(${snapshot.tokens.all_time.requests} req)`)}`)
 
+  // ── Active Requests ────────────────────────────────────────────────────────
+  lines.push('')
+  lines.push(`  ${themeColors.warningBold('⚡ Active Requests')} ${themeColors.dim(`(${snapshot.activeRequests?.length || 0})`)}`)
+  if (snapshot.activeRequests?.length > 0) {
+    for (const req of snapshot.activeRequests) {
+      const model = compactText(req.model, 24)
+      const current = compactText(req.current_model || 'Routing...', 24)
+      const duration = formatRouterDuration(Math.floor((Date.now() - req.started_at) / 1000))
+      const status = req.stalled ? themeColors.errorBold('STALLED?') : themeColors.success('Processing...')
+      const tokens = req.stream ? ` ${themeColors.dim(`(${req.tokens} tok)`)}` : ''
+      const shortId = req.request_id ? themeColors.dim(`[${req.request_id.slice(-4)}] `) : ''
+      lines.push(`  ${themeColors.dim('•')} ${shortId}${model} → ${themeColors.info(current)} ${status}${tokens} ${themeColors.dim(duration)}`)
+    }
+  } else {
+    lines.push(`  ${themeColors.dim('No active requests')}`)
+  }
+
   // ── Live Request Log (compact) ──────────────────────────────────────────────
   const requestRows = requestLogRows(state, snapshot)
   lines.push('')
   lines.push(`  ${themeColors.textBold('Recent Requests')}`)
   if (requestRows.length > 0) {
-    const header = `  ${padEndDisplay('Time', 10)} ${padEndDisplay('Model', 34)} ${padEndDisplay('Status', 8)} ${padEndDisplay('Latency', 9)} Detail`
+    const header = `  ${padEndDisplay('ID', 5)} ${padEndDisplay('Time', 10)} ${padEndDisplay('Model', 34)} ${padEndDisplay('Status', 8)} ${padEndDisplay('Latency', 9)} Detail`
     lines.push(themeColors.dim(header))
     for (const row of requestRows.slice(0, 6)) {
       const atMs = Date.parse(row.at)
@@ -1052,12 +1070,14 @@ export function renderRouterDashboard(state, deps = {}) {
         row.stream ? 'stream' : '',
         row.error || '',
       ].filter(Boolean).join(', ') || '—'
+      const shortId = row.request_id ? row.request_id.slice(-4) : '—'
       lines.push(
-        `  ${padEndDisplay(time, 10)} ` +
+        `  ${padEndDisplay(shortId, 5)} ` +
+        `${padEndDisplay(time, 10)} ` +
         `${compactText(row.model, 34)} ` +
         `${padEndDisplay(statusColor(statusText), 8)} ` +
         `${padEndDisplay(latency, 9)} ` +
-        `${compactText(detail, Math.max(10, width - 68)).trimEnd()}`
+        `${compactText(detail, Math.max(10, width - 74)).trimEnd()}`
       )
     }
   } else {

--- a/src/tui/command-palette.js
+++ b/src/tui/command-palette.js
@@ -219,12 +219,29 @@ const BASE_COMMAND_TREE = [
 /**
  * 📖 Build the command palette tree with dynamic model filters.
  * @param {Array} visibleModels - Optional list of visible models to create model filter entries
+ * @param {object} config - Optional FCM config to customize dynamic labels
  * @returns {Array} The command tree with model filters added
  */
-export function buildCommandPaletteTree(visibleModels = []) {
+export function buildCommandPaletteTree(visibleModels = [], config = null) {
   // 📖 Clone the base tree
   const tree = JSON.parse(JSON.stringify(BASE_COMMAND_TREE))
-  
+
+  // 📖 Update Normal mode label if config is provided
+  if (config) {
+    const normalInterval = config.settings?.pingInterval ?? 10000
+    const normalSec = Math.round(normalInterval / 1000)
+    const actionsNode = tree.find(n => n.id === 'actions')
+    const pingNode = actionsNode?.children.find(n => n.id === 'action-ping-mode')
+    const normalCommand = pingNode?.children.find(n => n.id === 'action-set-ping-normal')
+    if (normalCommand) {
+      normalCommand.label = `Normal mode (${normalSec}s)`
+      if (Array.isArray(normalCommand.keywords)) {
+        normalCommand.keywords = normalCommand.keywords.filter(k => !k.endsWith('s'))
+        normalCommand.keywords.push(`${normalSec}s`)
+      }
+    }
+  }
+
   // 📖 Find the filter-model category and add dynamic model entries
   const filterModelCategory = tree.find(cat => cat.id === 'filters')
     ?.children.find(sub => sub.id === 'filter-model')

--- a/src/tui/overlays.js
+++ b/src/tui/overlays.js
@@ -336,6 +336,8 @@ export function createOverlayRenderers(state, deps) {
       themeColors.dim('  ') +
       themeColors.footerLove('Made with 💖 & ☕ by ') +
       themeColors.link('\x1b]8;;https://github.com/vava-nessa\x1b\\vava-nessa\x1b]8;;\x1b\\') +
+      themeColors.dim('  •  ⭐ ') +
+      themeColors.link('\x1b]8;;https://github.com/vava-nessa/free-coding-models/graphs/contributors\x1b\\Contributors\x1b]8;;\x1b\\') +
       themeColors.dim('  •  💬 ') +
       themeColors.footerDiscord('\x1b]8;;https://discord.gg/ZTNFHvvCkU\x1b\\Join the Discord\x1b]8;;\x1b\\') +
       themeColors.dim('  •  ☕ ') +

--- a/src/tui/tui-state.js
+++ b/src/tui/tui-state.js
@@ -87,6 +87,9 @@ export function createTuiState({
 }) {
   const now = Date.now()
 
+  // 📖 Dynamic normal interval from config (default 10s)
+  const normalInterval = config.settings?.pingInterval ?? PING_MODE_INTERVALS.normal
+
   return {
     // 📖 Core data: model results (mutated in-place by ping loop)
     results,
@@ -107,6 +110,10 @@ export function createTuiState({
     pingInterval: PING_MODE_INTERVALS.speed,
     pingMode: 'speed',
     pingModeSource: 'startup',
+    pingModeIntervals: {
+      ...PING_MODE_INTERVALS,
+      normal: normalInterval,
+    },
     speedModeUntil: now + SPEED_MODE_DURATION_MS,
     lastPingTime: now,
     lastUserActivityAt: now,

--- a/test/test.js
+++ b/test/test.js
@@ -3155,9 +3155,10 @@ describe('router daemon integration hardening', () => {
             assert.equal(response.status, 200)
             // 📖 Partial data from the first model is visible to the client.
             assert.match(text, /partial-/)
-            // 📖 The router emits a synthetic SSE error event so the client knows
+            // 📖 The router emits a synthetic SSE caution message so the client knows
             // 📖 the stream was truncated and a failover is happening.
-            assert.match(text, /fcm_stream_failover/)
+            assert.match(text, /CAUTION/)
+            assert.match(text, /Stream truncated by router/)
             // 📖 Fallback stream from nvidia was appended.
             assert.match(text, /fallback/)
             assert.equal(groqProvider.requests.length, 1)

--- a/web/server.js
+++ b/web/server.js
@@ -51,7 +51,7 @@ import { benchmarkModel, BENCHMARK_TIMEOUT_MS, BENCHMARK_PROMPT } from '../src/c
 import { getInstallTargetModes, installProviderEndpoints, getConfiguredInstallableProviders, getProviderCatalogModels } from '../src/core/endpoint-installer.js'
 import { isModelCompatibleWithTool } from '../src/core/tool-metadata.js'
 import { sendUsageTelemetry } from '../src/core/telemetry.js'
-import { getRouterDaemonStatus, startRouterDaemonBackground, stopRouterDaemon, ROUTER_TOKENS_PATH, getRouterPortPath } from '../src/core/router-daemon.js'
+import { getRouterDaemonStatus, startRouterDaemonBackground, stopRouterDaemon, getRouterTokensPath, getRouterPortPath } from '../src/core/router-daemon.js'
 import { scanAllToolConfigs, softDeleteModel } from '../src/core/installed-models-manager.js'
 import {
   TASK_TYPES,
@@ -607,8 +607,9 @@ async function proxyToDaemon(path, options = {}) {
 
 function readTokenFile() {
   try {
-    if (!existsSync(ROUTER_TOKENS_PATH)) return null
-    return JSON.parse(readFileSync(ROUTER_TOKENS_PATH, 'utf8'))
+    const tokensPath = getRouterTokensPath()
+    if (!existsSync(tokensPath)) return null
+    return JSON.parse(readFileSync(tokensPath, 'utf8'))
   } catch { return null }
 }
 

--- a/web/src/components/router/RouterView.jsx
+++ b/web/src/components/router/RouterView.jsx
@@ -25,6 +25,16 @@ function formatUptime(seconds) {
   return `${s}s`
 }
 
+function formatTime(isoString) {
+  if (!isoString) return '—'
+  try {
+    const d = new Date(isoString)
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
+  } catch {
+    return '—'
+  }
+}
+
 function formatNumber(n) {
   if (typeof n !== 'number' || !Number.isFinite(n)) return '0'
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
@@ -119,7 +129,7 @@ export default function RouterView({ onClose, onToast, favorites }) {
     const interval = setInterval(() => {
       void fetchStatus()
       void fetchSets()
-    }, 5000)
+    }, 2000)
     return () => clearInterval(interval)
   }, [fetchStatus, fetchSets, fetchCatalog])
 
@@ -528,6 +538,7 @@ export default function RouterView({ onClose, onToast, favorites }) {
   const running = status?.ok
   const circuitBreakers = stats?.circuitBreakers || {}
   const requestLog = stats?.requestLog || []
+  const activeRequests = status?.activeRequests || []
 
   // 📖 routingOrder — the exact attempt order the daemon will use for the next
   // 📖 request (priority-first among healthy models). routingOrder[0] is the
@@ -957,6 +968,46 @@ export default function RouterView({ onClose, onToast, favorites }) {
             </div>
           )}
 
+          {/* Active Requests */}
+          {running && (
+            <div className={styles.section}>
+              <h3 className={styles.sectionTitle}>
+                <IconBolt size={14} className={activeRequests.length > 0 ? styles.pulse : ''} />
+                Active Requests ({activeRequests.length})
+              </h3>
+              {activeRequests.length > 0 ? (
+                <div className={styles.activeList}>
+                  {activeRequests.map((req) => (
+                    <div key={req.request_id} className={styles.activeRow}>
+                      <div className={styles.activeMain}>
+                        <span className={styles.activeModel}>
+                          <span className={styles.activeId} title={`Request ID: ${req.request_id}`}>
+                            {req.request_id.slice(-4)}
+                          </span>
+                          {req.model}
+                        </span>
+                        <span className={styles.activeStatus}>
+                          {req.stalled ? (
+                            <span className={styles.stalledText}>Stalled?</span>
+                          ) : (
+                            <span className={styles.processingText}>Processing...</span>
+                          )}
+                        </span>
+                      </div>
+                      <div className={styles.activeDetails}>
+                        <span className={styles.activeCurrentModel}>{req.current_model || 'Routing...'}</span>
+                        {req.stream && <span className={styles.activeTokens}>{req.tokens} tokens</span>}
+                        <span className={styles.activeUptime}>{formatUptime(Math.floor((Date.now() - req.started_at) / 1000))}</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className={styles.logEmpty}>No active requests.</div>
+              )}
+            </div>
+          )}
+
           {/* Request Log — always visible when running */}
           {running && (
             <div className={styles.section}>
@@ -972,6 +1023,12 @@ export default function RouterView({ onClose, onToast, favorites }) {
                   <div className={styles.logList}>
                     {requestLog.map((entry, i) => (
                       <div key={i} className={styles.logRow}>
+                        <span className={styles.logId} title={`Request ID: ${entry.request_id || '—'}`}>
+                          {entry.request_id ? entry.request_id.slice(-4) : '—'}
+                        </span>
+                        <span className={styles.logTime}>
+                          {formatTime(entry.at)}
+                        </span>
                         <span className={entry.error ? styles.logErr : styles.logOk}>
                           {entry.status || '—'}
                         </span>
@@ -982,7 +1039,13 @@ export default function RouterView({ onClose, onToast, favorites }) {
                         <span className={styles.logTokens}>
                           {entry.tokens > 0 ? formatNumber(entry.tokens) + ' tok' : ''}
                         </span>
-                        {entry.failover && <span className={styles.logFailover}>failover</span>}
+                        <span className={styles.logDetail}>
+                          {[
+                            entry.failover ? 'failover' : '',
+                            entry.stream ? 'stream' : '',
+                            entry.error || '',
+                          ].filter(Boolean).join(', ')}
+                        </span>
                       </div>
                     ))}
                   </div>

--- a/web/src/components/router/RouterView.module.css
+++ b/web/src/components/router/RouterView.module.css
@@ -355,6 +355,95 @@
 .circuitAuth { background: rgba(255, 140, 0, 0.15); color: #ff8c00; }
 .circuitUnknown { background: rgba(128, 128, 128, 0.15); color: #888; }
 
+.pulse {
+  color: #fbbf24;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0% { opacity: 0.4; }
+  50% { opacity: 1; }
+  100% { opacity: 0.4; }
+}
+
+.activeList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.activeRow {
+  background: rgba(251, 191, 36, 0.05);
+  border: 1px solid rgba(251, 191, 36, 0.2);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+
+.activeMain {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.activeModel {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text-primary, #e0e0e0);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.activeId {
+  color: var(--text-muted, #666);
+  font-size: 10px;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 1px 4px;
+  border-radius: 4px;
+  font-family: 'SF Mono', monospace;
+  font-weight: normal;
+}
+
+.activeStatus {
+  font-size: 12px;
+}
+
+.processingText {
+  color: #10b981;
+  font-weight: 500;
+}
+
+.stalledText {
+  color: #ef4444;
+  font-weight: 700;
+  animation: flash 1s infinite;
+}
+
+@keyframes flash {
+  0% { opacity: 1; }
+  50% { opacity: 0.5; }
+  100% { opacity: 1; }
+}
+
+.activeDetails {
+  display: flex;
+  gap: 12px;
+  font-size: 11px;
+  color: var(--text-muted, #888);
+}
+
+.activeCurrentModel {
+  color: var(--text-secondary, #b0b0b0);
+}
+
+.activeTokens {
+  background: rgba(255, 255, 255, 0.05);
+  padding: 0 4px;
+  border-radius: 3px;
+}
+
 /* Request Log */
 .logList {
   display: flex;
@@ -371,11 +460,31 @@
   font-family: 'SF Mono', monospace;
 }
 
+.logTime { color: var(--text-muted, #555); min-width: 60px; }
+.logId {
+  color: var(--text-muted, #666);
+  font-size: 9px;
+  min-width: 32px;
+  background: rgba(255, 255, 255, 0.03);
+  padding: 1px 3px;
+  border-radius: 3px;
+  text-align: center;
+  font-family: 'SF Mono', monospace;
+}
 .logOk { color: #00c864; min-width: 28px; }
 .logErr { color: #dc3545; min-width: 28px; }
 .logModel { color: var(--text-secondary, #aaa); flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .logLatency { color: var(--text-muted, #888); min-width: 50px; text-align: right; }
 .logTokens { color: var(--text-muted, #888); min-width: 60px; text-align: right; }
+.logDetail {
+  color: var(--text-muted, #666);
+  font-size: 10px;
+  flex: 1;
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .logFailover {
   font-size: 9px;
   padding: 1px 4px;


### PR DESCRIPTION
## Summary

This PR adds a one-command Proxmox VE deployment path, live visibility into in-flight router requests across all surfaces (TUI dashboard + web dashboard), and several router/config robustness improvements.

## 🚀 Proxmox VE Installation Scripts

- **`scripts/proxmoxve-create.sh`** — one-liner LXC container creation built on the [community-scripts/ProxmoxVE](https://github.com/community-scripts/ProxmoxVE) framework (Debian 12, 2 vCPU / 2 GB RAM / 8 GB disk defaults), including an `update` subcommand for in-place upgrades.
- **`scripts/proxmoxve-install.sh`** — container-side installer that sets up Node.js, clones the repo, builds the web dashboard, and registers the `fcm-web` systemd service on port `19280`.
- Post-install instructions guide users to add API keys and restart the service.

## ⚡ Router: Active Request Tracking

- The router daemon now maintains an `activeRequests` map recording per-request model, current candidate, attempt count, token progress, and last-activity timestamps (cleaned up in `finally`).
- **TUI dashboard** (`router-dashboard.js`): new "⚡ Active Requests" section showing live routing state (`Routing…` → provider, `Processing…` / `STALLED?`, duration, streamed tokens), plus a short request-ID column in the Recent Requests log.
- **Web dashboard** (`RouterView.jsx` + CSS): matching "Active Requests" panel, request IDs and timestamps in the request log, and faster polling (5 s → 2 s) for a more live feel.

## 🔁 Router: Retry & Reliability Improvements

- Expanded retryable HTTP status codes to include `408` and `504` (alongside the existing set), so transient timeouts trigger failover instead of surfacing as hard errors.
- Fixed retry attempt accounting to correctly perform `1 + maxRetries` total attempts.
- Added `getRouterTokensPath()` helper and switched `web/server.js` to it, removing a duplicated hardcoded token-file path.

## 🔧 Config: Safer Persistence & Normalization

- New `normalizeSyncSection` / `normalizeUpdaterSection` so `sync` and `updater` settings survive round-trips through the config file.
- `buildPersistedConfig` now **deep-merges** router sub-sections (`failover`, `probeIntervals`, `circuitBreaker`, `scoring`) — partial updates no longer silently reset custom values back to defaults.
- `normalizeRouterFailover` falls back to router-level values when section-level ones are absent.

## 🖥️ TUI Polish

- Command palette's "Normal mode" entry now displays the actual configured `pingInterval` instead of a hardcoded label.
- Added a ⭐ Contributors link to the overlay footer.

## 🧪 Tests

- Updated the synthetic SSE stream-truncation test to assert the new `CAUTION` / `Stream truncated by router` marker.
- All tests pass (`pnpm test`).

## 📝 Misc

- Added @lehneres to the README contributors table (Proxmox VE installation scripts).

## Cross-surface compatibility

Active request tracking lives in the shared core (`router-daemon.js` / `router-dashboard.js`) and is surfaced in **both** the CLI TUI dashboard and the web/Docker dashboard; config changes are surface-agnostic. No breaking changes to existing behavior.