### PR TITLE
fix: resolve Cloudflare {account_id} from CLOUDFLARE_ACCOUNT_ID env in launch paths

### DIFF
--- a/sources.js
+++ b/sources.js
@@ -598,7 +598,7 @@ export const sources = {
   },
   cloudflare: {
     name: 'Cloudflare AI',
-    url: 'https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1/chat/completions',
+    url: 'https://api.cloudflare.com/client/v4/accounts/{$CLOUDFLARE_ACCOUNT_ID}/ai/v1/chat/completions',
     quota: 'Free · 10k neurons/day',
     quotaCode: 'limited',
     models: cloudflare,

--- a/src/core/endpoint-installer.js
+++ b/src/core/endpoint-installer.js
@@ -171,7 +171,10 @@ function resolveProviderBaseUrl(providerKey) {
   if (providerKey === 'cloudflare') {
     const accountId = (process.env.CLOUDFLARE_ACCOUNT_ID || '').trim()
     if (!accountId) return null
-    return providerUrl.replace('{account_id}', accountId).replace(/\/chat\/completions$/i, '')
+    return providerUrl
+      .replace(/\{\$CLOUDFLARE_ACCOUNT_ID\}/g, encodeURIComponent(accountId))
+      .replace(/\{account_id\}/g, encodeURIComponent(accountId))
+      .replace(/\/chat\/completions$/i, '')
   }
 
   return providerUrl
@@ -189,7 +192,9 @@ function resolveGooseBaseUrl(providerKey) {
   if (providerKey === 'cloudflare') {
     const accountId = (process.env.CLOUDFLARE_ACCOUNT_ID || '').trim()
     if (!accountId) return null
-    return providerUrl.replace('{account_id}', accountId)
+    return providerUrl
+      .replace(/\{\$CLOUDFLARE_ACCOUNT_ID\}/g, encodeURIComponent(accountId))
+      .replace(/\{account_id\}/g, encodeURIComponent(accountId))
   }
   return providerUrl
 }

--- a/src/core/ping.js
+++ b/src/core/ping.js
@@ -56,12 +56,17 @@ const DISABLED_THINKING_RETRY_STATUSES = new Set([400, 422])
 const disabledThinkingUnsupportedProviders = new Set()
 
 // 📖 resolveCloudflareUrl: Cloudflare's OpenAI-compatible endpoint is account-scoped.
-// 📖 We resolve {account_id} from env so provider setup can stay simple in config.
+// 📖 We resolve the placeholder from the CLOUDFLARE_ACCOUNT_ID env var so provider
+// 📖 setup can stay simple in config. Supports both the `{account_id}` placeholder
+// 📖 and the explicit `{$CLOUDFLARE_ACCOUNT_ID}` form used in sources.js.
 export function resolveCloudflareUrl(url) {
   const accountId = (process.env.CLOUDFLARE_ACCOUNT_ID || '').trim()
-  if (!url.includes('{account_id}')) return url
-  if (!accountId) return url.replace('{account_id}', 'missing-account-id')
-  return url.replace('{account_id}', encodeURIComponent(accountId))
+  const hasPlaceholder = url.includes('{$CLOUDFLARE_ACCOUNT_ID}') || url.includes('{account_id}')
+  if (!hasPlaceholder) return url
+  const replacement = accountId ? encodeURIComponent(accountId) : 'missing-account-id'
+  return url
+    .replace(/\{\$CLOUDFLARE_ACCOUNT_ID\}/g, replacement)
+    .replace(/\{account_id\}/g, replacement)
 }
 
 // 📖 buildChatCompletionPingBody: Use the smallest useful chat-completion probe.

--- a/src/core/tool-launchers.js
+++ b/src/core/tool-launchers.js
@@ -50,6 +50,7 @@ import { PROVIDER_METADATA } from './provider-metadata.js'
 import { resolveToolBinaryPath } from './tool-bootstrap.js'
 import { ensureDir, readJson, writeJson } from './shared-helpers.js'
 import { parseContextWindow } from './endpoint-installer.js'
+import { resolveCloudflareUrl } from './ping.js'
 
 const OPENAI_COMPAT_ENV_KEYS = [
   'OPENAI_API_KEY',
@@ -108,10 +109,15 @@ function backupIfExists(filePath) {
 function getProviderBaseUrl(providerKey) {
   const url = sources[providerKey]?.url
   if (!url) return null
-  return url
+  let resolvedUrl = url
     .replace(/\/chat\/completions$/i, '')
     .replace(/\/responses$/i, '')
     .replace(/\/predictions$/i, '')
+  // 📖 Cloudflare uses account_id in URL - resolve from CLOUDFLARE_ACCOUNT_ID env var
+  if (providerKey === 'cloudflare') {
+    resolvedUrl = resolveCloudflareUrl(resolvedUrl)
+  }
+  return resolvedUrl
 }
 
 function deleteEnvKeys(env, keys) {
@@ -579,9 +585,9 @@ export function writeZCodeConfig(model, config, paths = getDefaultToolPaths()) {
 
   const providerKey = model.providerKey || 'nvidia'
   const apiKey = getApiKey(config, providerKey)
-  const baseUrl = sources[providerKey]?.url
-    ? sources[providerKey].url.replace(/\/chat\/completions$/i, '').replace(/\/responses$/i, '').replace(/\/predictions$/i, '')
-    : null
+  // 📖 Use getProviderBaseUrl so Cloudflare's {account_id} placeholder is resolved
+  // 📖 (raw sources[].url would leave it literal and ZCode would fail on Cloudflare models).
+  const baseUrl = getProviderBaseUrl(providerKey)
   const providerId = `fcm-${providerKey}`
   const providerLabel = `FCM ${sources[providerKey]?.name || providerKey}`
 
@@ -838,7 +844,11 @@ export function prepareExternalToolLaunch(mode, model, config, options = {}) {
   }
 
   if (mode === 'goose') {
-    const gooseBaseUrl = sources[model.providerKey]?.url || baseUrl || ''
+    // 📖 Always use the resolved provider base URL from buildToolEnv (getProviderBaseUrl),
+    // 📖 which substitutes Cloudflare's {account_id} placeholder via resolveCloudflareUrl.
+    // 📖 Using the raw sources[].url would leave the literal {account_id} in the Goose
+    // 📖 provider config, so Goose would POST to /accounts/{account_id}/... and 400.
+    const gooseBaseUrl = baseUrl
     const gooseModelId = resolveLauncherModelId(model)
     const result = writeGooseConfig({ ...model, modelId: gooseModelId }, apiKey, gooseBaseUrl, model.providerKey, paths)
     env.GOOSE_PROVIDER = `fcm-${model.providerKey}`


### PR DESCRIPTION
## Problem
Cloudflare's OpenAI-compatible endpoint is account-scoped
(/client/v4/accounts/{account_id}/ai/v1/...). External-tool launchers
(Goose, ZCode) were built from the raw sources[].url, leaving the literal
{account_id} placeholder in the generated config — so requests hit
/accounts/{account_id}/.../chat/completions and Cloudflare returned 404.

## Fix
- sources.js: use the explicit {$CLOUDFLARE_ACCOUNT_ID} placeholder.
- ping.js resolveCloudflareUrl: substitute both {$CLOUDFLARE_ACCOUNT_ID}
  and {account_id} from CLOUDFLARE_ACCOUNT_ID (or missing-account-id if unset).
- endpoint-installer.js: replace the new placeholder on direct + Goose installs.
- tool-launchers.js: route Goose and ZCode base URLs through
  getProviderBaseUrl so Cloudflare's account-scoped URL is resolved instead of
  leaking the literal placeholder.

Requires CLOUDFLARE_ACCOUNT_ID to be exported in the environment that runs FCM.

## Scope
Cloudflare-account-id fix only — excludes the LiteLLM proxy toggle and the Groq
reasoning_content fixes, which are tracked separately.