### PR TITLE
fix: disable Groq reasoning_content for Qwen Code and Goose (no LiteLLM)

### DIFF
--- a/src/core/tool-launchers.js
+++ b/src/core/tool-launchers.js
@@ -293,6 +293,13 @@ function writeQwenConfig(model, providerKey, apiKey, baseUrl, paths = getDefault
     name: model.label,
     envKey: ENV_VAR_NAMES[providerKey] || 'OPENAI_API_KEY',
     baseUrl,
+    ...(providerKey === 'groq' && {
+      // 📖 Groq rejects assistant messages that carry `reasoning_content`
+      // 📖 (400: property 'reasoning_content' is unsupported). Disabling Qwen
+      // 📖 Code's thinking mode stops it from emitting that field on Groq.
+      generationConfig: { reasoning: false },
+      extra_body: { chat_template_kwargs: { enable_thinking: false } },
+    }),
   }
   const filtered = config.modelProviders.openai.filter((entry) => entry?.id !== model.modelId)
   filtered.unshift(nextEntry)
@@ -348,6 +355,12 @@ function writeGooseConfig(model, apiKey, baseUrl, providerKey, paths = getDefaul
     models: [{ name: model.modelId, context_limit: parseContextWindow(model.ctx) }],
     supports_streaming: true,
     requires_auth: true,
+    ...(providerKey === 'groq' && {
+      // 📖 Groq rejects assistant messages that carry `reasoning_content`
+      // 📖 (400: property 'reasoning_content' is unsupported). `clear_thinking`
+      // 📖 makes Goose omit that field when talking to Groq.
+      clear_thinking: true,
+    }),
   }
   writeFileSync(providerFilePath, JSON.stringify(providerConfig, null, 2) + '\n')
 

--- a/test/test.js
+++ b/test/test.js
@@ -4544,6 +4544,36 @@ describe('tool launch preparation', () => {
       rmSync(dir, { recursive: true, force: true })
     }
   })
+
+  it('disables Groq reasoning_content for Qwen and Goose without LiteLLM', () => {
+    const dir = join(tmpdir(), `fcm-groq-reasoning-${process.pid}-${Date.now()}`)
+    mkdirSync(dir, { recursive: true })
+    const paths = createToolPaths(dir)
+    const config = { apiKeys: { groq: 'gsk-test', nvidia: 'nvapi-test' } }
+    const groqModel = { providerKey: 'groq', modelId: 'openai/gpt-oss-120b', label: 'GPT OSS 120B', ctx: '128k' }
+    const nvidiaModel = { providerKey: 'nvidia', modelId: 'deepseek-ai/deepseek-v4-flash-0731', label: 'DeepSeek V4 Flash', ctx: '1M' }
+    try {
+      // 📖 Goose: clear_thinking must be added only for Groq
+      prepareExternalToolLaunch('goose', groqModel, config, { paths, inheritedEnv: { PATH: process.env.PATH || '' } })
+      const groqGooseProvider = JSON.parse(readFileSync(join(paths.gooseProvidersDir, 'fcm-groq.json'), 'utf8'))
+      assert.equal(groqGooseProvider.clear_thinking, true)
+
+      prepareExternalToolLaunch('goose', nvidiaModel, config, { paths, inheritedEnv: { PATH: process.env.PATH || '' } })
+      const nvGooseProvider = JSON.parse(readFileSync(join(paths.gooseProvidersDir, 'fcm-nvidia.json'), 'utf8'))
+      assert.equal(nvGooseProvider.clear_thinking, undefined)
+
+      // 📖 Qwen: generationConfig.reasoning:false must be added only for Groq
+      prepareExternalToolLaunch('qwen', groqModel, config, { paths, inheritedEnv: { PATH: process.env.PATH || '' } })
+      const groqQwenConfig = JSON.parse(readFileSync(paths.qwenConfigPath, 'utf8'))
+      assert.deepEqual(groqQwenConfig.modelProviders.openai[0].generationConfig, { reasoning: false })
+
+      prepareExternalToolLaunch('qwen', nvidiaModel, config, { paths, inheritedEnv: { PATH: process.env.PATH || '' } })
+      const nvQwenConfig = JSON.parse(readFileSync(paths.qwenConfigPath, 'utf8'))
+      assert.equal(nvQwenConfig.modelProviders.openai[0].generationConfig, undefined)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('openclaw selected model persistence', () => {


### PR DESCRIPTION
## Problem
Groq rejects assistant messages that carry reasoning_content with HTTP 400:
'property reasoning_content is unsupported'. Qwen Code round-trips that
field on every turn, and Goose can emit it too, so selecting a Groq model in
either tool fails immediately.

## Fix (isolated from LiteLLM)
- writeQwenConfig: adds generationConfig: { reasoning: false } for Groq
  models - disables Qwen Code's thinking mode so the field is never produced.
- writeGooseConfig: adds clear_thinking: true for Groq models.

No LiteLLM proxy dependency - applied directly to the provider config. Other
providers (e.g. nvidia) are unaffected (verified by tests).

## Tests
- Adds a test asserting clear_thinking: true (Goose) and
  generationConfig.reasoning: false (Qwen) for Groq only, and that neither
  is added for non-Groq providers.

## Scope
Groq reasoning_content fix only - excludes the Cloudflare account-id fix
(PR #170) and the LiteLLM proxy feature.